### PR TITLE
Implement initial improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview",
     "audit:components": "node scripts/component-analysis.js",
     "audit:a11y": "node scripts/accessibility-audit.js",
@@ -63,6 +64,7 @@
     "tsx": "^4.19.4",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/context/reducers/caseReducer.ts
+++ b/src/context/reducers/caseReducer.ts
@@ -1,0 +1,60 @@
+import { AppState, Action } from '../DataContext';
+import { AuditLog } from '../../types/schema';
+
+export function caseReducer(
+  state: AppState,
+  action: Action,
+  now: string,
+  createAuditLog: (entity: AuditLog['entityType'], id: string, action: AuditLog['action'], details: string) => AuditLog
+): { state: AppState; auditLog: AuditLog | null } | null {
+  let newState = state;
+  let auditLog: AuditLog | null = null;
+
+  switch (action.type) {
+    case 'ADD_CASE':
+      newState = {
+        ...state,
+        cases: [...state.cases, action.payload],
+      };
+      auditLog = createAuditLog('Case', action.payload.caseId, 'Create', 'Case created');
+      break;
+
+    case 'UPDATE_CASE':
+      newState = {
+        ...state,
+        cases: state.cases.map(c =>
+          c.caseId === action.payload.caseId ? { ...action.payload, updatedAt: now } : c
+        ),
+      };
+      auditLog = createAuditLog('Case', action.payload.caseId, 'Update', 'Case updated');
+      break;
+
+    case 'DELETE_CASE':
+      const caseId = action.payload;
+      newState = {
+        ...state,
+        cases: state.cases.filter(c => c.caseId !== caseId),
+        hearings: state.hearings.filter(h => h.caseId !== caseId),
+        documents: state.documents.filter(d => d.caseId !== caseId),
+        invoices: state.invoices.filter(i => i.caseId !== caseId),
+        zoomLinks: state.zoomLinks.filter(z => z.caseId !== caseId),
+      };
+
+      const affectedDocIds = state.documents.filter(d => d.caseId === caseId).map(d => d.docId);
+      const affectedInvoiceIds = state.invoices.filter(i => i.caseId === caseId).map(i => i.invoiceId);
+
+      newState = {
+        ...newState,
+        serviceLogs: state.serviceLogs.filter(sl => !affectedDocIds.includes(sl.docId)),
+        paymentPlans: state.paymentPlans.filter(pp => !affectedInvoiceIds.includes(pp.invoiceId)),
+      };
+
+      auditLog = createAuditLog('Case', caseId, 'Delete', 'Case deleted with all related records');
+      break;
+
+    default:
+      return null;
+  }
+
+  return { state: newState, auditLog };
+}

--- a/src/utils/dataImport/invoicesParser.ts
+++ b/src/utils/dataImport/invoicesParser.ts
@@ -16,7 +16,6 @@ export function parseInvoices(
   finalInvoices: any[],
   caseMapping: Map<string, string>
 ): Invoice[] {
-  const invoices: Invoice[] = [];
   const invoiceMap = new Map<string, Invoice>();
   
   // Process invoices from each source

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { formatCurrency } from './utils';
+
+describe('formatCurrency', () => {
+  it('formats number as USD currency', () => {
+    expect(formatCurrency(1234.5)).toBe('$1,234.50');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,4 +20,8 @@ export default defineConfig({
   ssr: {
     noExternal: ['papaparse'],
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- export AppState and Action types
- start breaking down reducer with a new `caseReducer`
- setup vitest testing
- add example test for `formatCurrency`
- remove unused variable from invoices parser

## Testing
- `npm run lint`
- `npm run test` *(fails: vitest not installed)*