### PR TITLE
Add Node auth test and env fallbacks

### DIFF
--- a/docs/api/e-filing/README.md
+++ b/docs/api/e-filing/README.md
@@ -123,3 +123,32 @@ To test error handling:
 2. Submit a filing and verify appropriate error messages appear
 3. Check that exponential backoff retry mechanism works by monitoring network requests
 4. Verify that fatal errors (server errors, permission errors) display clear toast notifications
+
+### Testing authentication
+
+Use the Node script `scripts/test-auth.js` to verify your credentials.
+
+1. Create a `.env.local` file in the project root with:
+
+   ```
+   VITE_EFILE_BASE_URL=https://api.uslegalpro.com/v4
+   VITE_EFILE_CLIENT_TOKEN=EVICT87
+   VITE_EFILE_USERNAME=czivin@wolfsolovy.com
+   VITE_EFILE_PASSWORD=Zuj90820*
+   ```
+
+2. Restart Vite to load the new variables:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Run the authentication test:
+
+   ```bash
+   npm run test:auth
+   ```
+
+4. Open your browser's DevTools Network tab and look for the
+   `POST /v4/il/user/authenticate` request. Verify the clienttoken header,
+   request payload and response token.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test:e2e": "cypress run",
-    "test:efile": "cypress run --spec \"cypress/e2e/*{efile,efile-offline}.cy.js\""
+    "test:efile": "cypress run --spec \"cypress/e2e/*{efile,efile-offline}.cy.js\"",
+    "test:auth": "node --loader ts-node/esm scripts/test-auth.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.13",

--- a/scripts/test-auth.js
+++ b/scripts/test-auth.js
@@ -1,52 +1,9 @@
 // @ts-check
 import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import axios from 'axios';
+import { authenticate } from '../src/utils/efile/auth.ts';
 
 // Load environment variables from .env.local
-dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-/**
- * Authenticate with the e-filing API
- * @param {Object} params
- * @param {string} params.username
- * @param {string} params.password
- */
-async function authenticate({ username, password }) {
-  const baseURL = process.env.VITE_EFILE_BASE_URL;
-  const clientToken = process.env.VITE_EFILE_CLIENT_TOKEN;
-  
-  if (!baseURL || !clientToken) {
-    throw new Error('Missing required environment variables: VITE_EFILE_BASE_URL or VITE_EFILE_CLIENT_TOKEN');
-  }
-  
-  console.log(`Authenticating with ${baseURL}/il/user/authenticate`);
-  console.log(`Using client token: ${clientToken.substring(0, 2)}${'*'.repeat(clientToken.length - 2)}`);
-  console.log(`Username: ${username}`);
-  console.log(`Password: ${'*'.repeat(password.length)}`);
-  
-  try {
-    const response = await axios.post(
-      `${baseURL}/il/user/authenticate`,
-      { data: { username, password } },
-      { headers: { clienttoken: clientToken } }
-    );
-    
-    return response.data.item.auth_token;
-  } catch (error) {
-    console.error('Authentication error:');
-    if (error.response) {
-      console.error(`Status: ${error.response.status}`);
-      console.error('Response data:', error.response.data);
-    } else {
-      console.error(error.message);
-    }
-    throw error;
-  }
-}
+dotenv.config({ path: '.env.local' });
 
 // Main execution
 (async () => {

--- a/src/utils/efile/apiClient.ts
+++ b/src/utils/efile/apiClient.ts
@@ -1,13 +1,19 @@
 import axios from 'axios';
 import { EFileError, AuthenticationError, SubmissionError, ServerError } from './errors';
 
+const isBrowser = typeof window !== 'undefined';
+
 // Configuration for different request types
 const DEFAULT_TIMEOUT = 30000; // 30 seconds for regular requests
 const UPLOAD_TIMEOUT = 120000; // 2 minutes for file uploads
 const MAX_CONTENT_SIZE = 10 * 1024 * 1024; // 10MB max file size
 
+const BASE_URL = isBrowser
+  ? import.meta.env.VITE_EFILE_BASE_URL
+  : process.env.VITE_EFILE_BASE_URL;
+
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_EFILE_BASE_URL,
+  baseURL: BASE_URL,
   timeout: DEFAULT_TIMEOUT,
   maxContentLength: MAX_CONTENT_SIZE,
   maxBodyLength: MAX_CONTENT_SIZE,

--- a/src/utils/efile/auth.ts
+++ b/src/utils/efile/auth.ts
@@ -1,12 +1,20 @@
 import type { AuthenticateRequest, AuthenticateResponse } from '@/types/efile';
 import { apiClient } from './apiClient';
 
-const CLIENT_TOKEN = import.meta.env.VITE_EFILE_CLIENT_TOKEN;
+const isBrowser = typeof window !== 'undefined';
 
-export async function authenticate(
-  username: string,
-  password: string,
-): Promise<string> {
+const CLIENT_TOKEN =
+  isBrowser
+    ? import.meta.env.VITE_EFILE_CLIENT_TOKEN
+    : process.env.VITE_EFILE_CLIENT_TOKEN;
+
+export async function authenticate({
+  username,
+  password,
+}: {
+  username: string;
+  password: string;
+}): Promise<string> {
   const req: AuthenticateRequest = { data: { username, password } };
   const { data } = await apiClient.post<AuthenticateResponse>(
     '/il/user/authenticate',
@@ -42,9 +50,13 @@ export async function ensureAuth(
   if (currentToken && expires && !isTokenExpired(expires)) {
     return currentToken;
   }
-  const username = import.meta.env.VITE_EFILE_USERNAME;
-  const password = import.meta.env.VITE_EFILE_PASSWORD;
-  const token = await authenticate(username, password);
+  const username = isBrowser
+    ? import.meta.env.VITE_EFILE_USERNAME
+    : process.env.VITE_EFILE_USERNAME;
+  const password = isBrowser
+    ? import.meta.env.VITE_EFILE_PASSWORD
+    : process.env.VITE_EFILE_PASSWORD;
+  const token = await authenticate({ username, password });
   // Docs do not specify expiration; assume 1 hour
   const expiry = Date.now() + 60 * 60 * 1000;
   dispatch({ type: 'SET_TOKEN', token, expires: expiry });


### PR DESCRIPTION
## Summary
- allow efile utils to use process.env when run in Node
- import authenticate in `scripts/test-auth.js`
- add `test:auth` npm script
- document authentication testing steps

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `node --loader ts-node/esm scripts/test-auth.js` *(fails: missing credentials in CI)*