### PR TITLE
Refine ESLint admin handling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,7 +8,6 @@ node_modules/
 
 # Areas with known issues that we'll fix separately
 src/utils/dataImport/
-src/components/admin/
 src/utils/refine/
 
 # Specific files with heavy types or known issues

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist', 'node_modules', 'src/utils/dataImport', 'src/components/admin'] },
+  { ignores: ['dist', 'node_modules', 'src/utils/dataImport'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
@@ -27,6 +27,14 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': 'warn',
       'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+  {
+    files: ['src/components/admin/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      'react-hooks/exhaustive-deps': 'off',
     },
   }
 );


### PR DESCRIPTION
## Summary
- update `.eslintignore` to lint admin components
- remove admin from global `ignores` list
- disable strict rules for admin component files

## Testing
- `npm run lint` *(fails: no-case-declarations, prefer-const, etc.)*