### PR TITLE
Fix auth client token header

### DIFF
--- a/src/utils/efile/auth.ts
+++ b/src/utils/efile/auth.ts
@@ -1,7 +1,9 @@
 import type { AuthenticateRequest, AuthenticateResponse } from '@/types/efile';
 import { apiClient } from './apiClient';
 
-const CLIENT_TOKEN = import.meta.env.VITE_EFILE_CLIENT_TOKEN;
+const CLIENT_TOKEN =
+  import.meta.env.VITE_EFILE_CLIENT_TOKEN ||
+  process.env.VITE_EFILE_CLIENT_TOKEN;
 
 export async function authenticate(
   username: string,

--- a/tests/unit/utils/efile/auth.test.ts
+++ b/tests/unit/utils/efile/auth.test.ts
@@ -1,16 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { authenticate, storeToken, getStoredToken, isTokenExpired } from '@/utils/efile/auth';
-import { apiClient } from '@/utils/efile/apiClient';
+process.env.VITE_EFILE_CLIENT_TOKEN = 'EVICT87';
 
-// Mock the apiClient module
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
 vi.mock('@/utils/efile/apiClient', () => ({
   apiClient: {
     post: vi.fn(),
   },
 }));
 
-// Mock environment variables
-vi.stubEnv('VITE_EFILE_CLIENT_TOKEN', 'EVICT87');
+import { apiClient } from '@/utils/efile/apiClient';
+const { authenticate, storeToken, getStoredToken, isTokenExpired } = await import('@/utils/efile/auth');
 
 describe('Authentication utilities', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- read E-Filing client token from `import.meta.env` or `process.env`
- ensure `clienttoken` header is set in unit tests

## Testing
- `npm run test:unit`