### PR TITLE
Fix update timestamp trigger for Supabase

### DIFF
--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -22,7 +22,7 @@ const Pagination: React.FC<PaginationProps> = ({
   const getPageNumbers = () => {
     const maxPagesShown = 5;
     let startPage = Math.max(1, currentPage - Math.floor(maxPagesShown / 2));
-    let endPage = Math.min(totalPages, startPage + maxPagesShown - 1);
+    const endPage = Math.min(totalPages, startPage + maxPagesShown - 1);
     
     if (endPage - startPage + 1 < maxPagesShown) {
       startPage = Math.max(1, endPage - maxPagesShown + 1);

--- a/src/components/ui/shadcn-input.tsx
+++ b/src/components/ui/shadcn-input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/supabase/migrations/20250523120000_fix_update_timestamp_trigger.sql
+++ b/supabase/migrations/20250523120000_fix_update_timestamp_trigger.sql
@@ -1,0 +1,25 @@
+-- Fix update timestamp trigger for cases, hearings, and documents
+DROP FUNCTION IF EXISTS public.update_updated_at_column;
+
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_TABLE_NAME = 'cases' THEN
+        NEW."updatedAt" = now();
+    ELSE
+        NEW.updated_at = now();
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate triggers to use the new function
+DROP TRIGGER IF EXISTS update_hearings_updated_at ON public.hearings;
+CREATE TRIGGER update_hearings_updated_at
+BEFORE UPDATE ON public.hearings
+FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_documents_updated_at ON public.documents;
+CREATE TRIGGER update_documents_updated_at
+BEFORE UPDATE ON public.documents
+FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- update Pagination types to appease lint
- type InputProps as a type alias
- add migration to fix `updated_at` trigger logic for `cases`, `hearings`, and `documents`

## Testing
- `npm run lint`
- `npm run test:unit`
