### PR TITLE
Fix invalid date display in CaseList table

### DIFF
--- a/src/components/cases/CaseList.tsx
+++ b/src/components/cases/CaseList.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useData } from '../../context/DataContext';
 import { supabase } from '../../lib/supabaseClient';
-import { format } from 'date-fns';
+import { format, parseISO, isValid } from 'date-fns';
 import { Plus, Filter, Search, Calendar } from 'lucide-react';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
@@ -167,8 +167,17 @@ const CaseList: React.FC = () => {
     },
     {
       header: 'Intake Date',
-      accessor: (item: typeof state.cases[0]) => 
-        format(new Date(item.intakeDate), 'MMM d, yyyy'),
+      accessor: (item: typeof state.cases[0]) => {
+        const date = typeof item.intakeDate === 'string' 
+          ? parseISO(item.intakeDate) 
+          : item.intakeDate instanceof Date 
+          ? item.intakeDate 
+          : null;
+        
+        return date && isValid(date) 
+          ? format(date, 'MMM d, yyyy') 
+          : 'Invalid Date';
+      },
       sortable: true,
     },
   ];


### PR DESCRIPTION
## Summary
Fixes 'Invalid time value' RangeError in CaseList table when rendering malformed dates.

## Changes
- Add safe date parsing with `parseISO` and `isValid` from date-fns
- Guard Intake Date table column against invalid date values
- Display 'Invalid Date' for unparseable values instead of throwing error
- Handle string, Date, and null date types gracefully

## Scope
- **ONLY** fixes table display issues
- **NO** changes to filter logic or dropdown options
- **NO** changes to existing date filtering functionality
- Single file, minimal change (12 insertions, 3 deletions)

## Testing
- ✅ Build successful
- ✅ TypeScript compilation clean  
- ✅ All 22 unit tests passing
- ✅ No changes to existing filter functionality

## Before/After
**Before**: `RangeError: Invalid time value` when displaying malformed dates
**After**: Shows 'Invalid Date' text instead of throwing error

This is a focused fix that only addresses the console error without touching any existing functionality.