### PR TITLE
Fix date parsing and unique keys

### DIFF
--- a/src/components/cases/CaseDetail.tsx
+++ b/src/components/cases/CaseDetail.tsx
@@ -106,14 +106,30 @@ const CaseDetail: React.FC = () => {
     },
     {
       header: 'Date',
-      accessor: (item: typeof state.hearings[0]) => 
-        format(new Date(item.hearingDate), 'MMM d, yyyy'),
+      accessor: (item: typeof state.hearings[0]) => {
+        const date = typeof item.hearingDate === 'string'
+          ? parseISO(item.hearingDate)
+          : item.hearingDate instanceof Date
+          ? item.hearingDate
+          : null;
+        return date && isValid(date)
+          ? format(date, 'MMM d, yyyy')
+          : 'Invalid Date';
+      },
       sortable: true,
     },
     {
       header: 'Time',
-      accessor: (item: typeof state.hearings[0]) => 
-        format(new Date(item.hearingDate), 'h:mm a'),
+      accessor: (item: typeof state.hearings[0]) => {
+        const date = typeof item.hearingDate === 'string'
+          ? parseISO(item.hearingDate)
+          : item.hearingDate instanceof Date
+          ? item.hearingDate
+          : null;
+        return date && isValid(date)
+          ? format(date, 'h:mm a')
+          : 'Invalid Date';
+      },
       sortable: false,
     },
     {
@@ -147,8 +163,16 @@ const CaseDetail: React.FC = () => {
     },
     {
       header: 'Created',
-      accessor: (item: typeof state.documents[0]) => 
-        format(new Date(item.createdAt), 'MMM d, yyyy'),
+      accessor: (item: typeof state.documents[0]) => {
+        const date = typeof item.createdAt === 'string'
+          ? parseISO(item.createdAt)
+          : item.createdAt instanceof Date
+          ? item.createdAt
+          : null;
+        return date && isValid(date)
+          ? format(date, 'MMM d, yyyy')
+          : 'Invalid Date';
+      },
       sortable: true,
     },
     {
@@ -178,8 +202,16 @@ const CaseDetail: React.FC = () => {
     },
     {
       header: 'Issue Date',
-      accessor: (item: typeof state.invoices[0]) => 
-        format(new Date(item.issueDate), 'MMM d, yyyy'),
+      accessor: (item: typeof state.invoices[0]) => {
+        const date = typeof item.issueDate === 'string'
+          ? parseISO(item.issueDate)
+          : item.issueDate instanceof Date
+          ? item.issueDate
+          : null;
+        return date && isValid(date)
+          ? format(date, 'MMM d, yyyy')
+          : 'Invalid Date';
+      },
       sortable: true,
     },
     {
@@ -200,8 +232,16 @@ const CaseDetail: React.FC = () => {
   const activityColumns = [
     {
       header: 'Time',
-      accessor: (item: typeof state.auditLogs[0]) => 
-        format(new Date(item.timestamp), 'MMM d, h:mm a'),
+      accessor: (item: typeof state.auditLogs[0]) => {
+        const date = typeof item.timestamp === 'string'
+          ? parseISO(item.timestamp)
+          : item.timestamp instanceof Date
+          ? item.timestamp
+          : null;
+        return date && isValid(date)
+          ? format(date, 'MMM d, h:mm a')
+          : 'Invalid Date';
+      },
       sortable: true,
     },
     {
@@ -393,7 +433,16 @@ const CaseDetail: React.FC = () => {
               <div>
                 <p className="text-sm font-medium text-gray-900">Next Hearing</p>
                 <p className="text-xs text-primary-600">
-                  {format(new Date(scheduledHearing.hearingDate), 'MMMM d, yyyy')} at {format(new Date(scheduledHearing.hearingDate), 'h:mm a')}
+                  {(() => {
+                    const date = typeof scheduledHearing.hearingDate === 'string'
+                      ? parseISO(scheduledHearing.hearingDate)
+                      : scheduledHearing.hearingDate instanceof Date
+                      ? scheduledHearing.hearingDate
+                      : null;
+                    return date && isValid(date)
+                      ? `${format(date, 'MMMM d, yyyy')} at ${format(date, 'h:mm a')}`
+                      : 'Invalid Date';
+                  })()}
                 </p>
               </div>
             </div>
@@ -434,7 +483,16 @@ const CaseDetail: React.FC = () => {
                   Intake Date
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900">
-                  {format(new Date(caseData.intakeDate), 'MMMM d, yyyy')}
+                  {(() => {
+                    const date = typeof caseData.intakeDate === 'string'
+                      ? parseISO(caseData.intakeDate)
+                      : caseData.intakeDate instanceof Date
+                      ? caseData.intakeDate
+                      : null;
+                    return date && isValid(date)
+                      ? format(date, 'MMMM d, yyyy')
+                      : 'Invalid Date';
+                  })()}
                 </dd>
               </div>
             </dl>

--- a/src/components/contacts/ContactDetail.tsx
+++ b/src/components/contacts/ContactDetail.tsx
@@ -15,7 +15,7 @@ import {
 import Card from '../ui/Card';
 import Button from '../ui/Button';
 import { Contact } from '../../types/schema';
-import { format } from 'date-fns';
+import { format, parseISO, isValid } from 'date-fns';
 
 const ContactDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -195,9 +195,18 @@ const ContactDetail: React.FC = () => {
                 </div>
                 <div className="ml-3">
                   <p className="text-sm font-medium text-gray-900">Added</p>
-                  <p className="text-sm text-gray-500">
-                    {format(new Date(contact.created_at), 'MMMM d, yyyy')}
-                  </p>
+                    <p className="text-sm text-gray-500">
+                      {(() => {
+                        const date = typeof contact.created_at === 'string'
+                          ? parseISO(contact.created_at)
+                          : contact.created_at instanceof Date
+                          ? contact.created_at
+                          : null;
+                        return date && isValid(date)
+                          ? format(date, 'MMMM d, yyyy')
+                          : 'Invalid Date';
+                      })()}
+                    </p>
                 </div>
               </div>
             </div>

--- a/src/components/documents/DocumentDetail.tsx
+++ b/src/components/documents/DocumentDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Download, Edit, Trash2, FileText, AlertCircle, ExternalLink } from 'lucide-react';
-import { format } from 'date-fns';
+import { format, parseISO, isValid } from 'date-fns';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
 import { useDocuments } from '../../hooks/useDocuments';
@@ -247,23 +247,50 @@ const DocumentDetail: React.FC = () => {
               <div>
                 <label className="text-sm font-medium text-gray-700">Service Date</label>
                 <p className="mt-1 text-sm text-gray-900">
-                  {format(new Date(document.serviceDate), 'MMM d, yyyy')}
+                  {(() => {
+                    const date = typeof document.serviceDate === 'string'
+                      ? parseISO(document.serviceDate)
+                      : document.serviceDate instanceof Date
+                      ? document.serviceDate
+                      : null;
+                    return date && isValid(date)
+                      ? format(date, 'MMM d, yyyy')
+                      : 'Invalid Date';
+                  })()}
                 </p>
               </div>
             )}
             
             <div>
               <label className="text-sm font-medium text-gray-700">Created</label>
-              <p className="mt-1 text-sm text-gray-900">
-                {document.createdAt ? format(new Date(document.createdAt), 'MMM d, yyyy') : 'Unknown'}
-              </p>
+                <p className="mt-1 text-sm text-gray-900">
+                  {document.createdAt ? (() => {
+                    const date = typeof document.createdAt === 'string'
+                      ? parseISO(document.createdAt)
+                      : document.createdAt instanceof Date
+                      ? document.createdAt
+                      : null;
+                    return date && isValid(date)
+                      ? format(date, 'MMM d, yyyy')
+                      : 'Invalid Date';
+                  })() : 'Unknown'}
+                </p>
             </div>
             
             {document.updatedAt && (
               <div>
                 <label className="text-sm font-medium text-gray-700">Last Updated</label>
                 <p className="mt-1 text-sm text-gray-900">
-                  {format(new Date(document.updatedAt), 'MMM d, yyyy')}
+                  {(() => {
+                    const date = typeof document.updatedAt === 'string'
+                      ? parseISO(document.updatedAt)
+                      : document.updatedAt instanceof Date
+                      ? document.updatedAt
+                      : null;
+                    return date && isValid(date)
+                      ? format(date, 'MMM d, yyyy')
+                      : 'Invalid Date';
+                  })()}
                 </p>
               </div>
             )}

--- a/src/components/invoices/InvoiceDetail.tsx
+++ b/src/components/invoices/InvoiceDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useData } from '../../context/DataContext';
-import { format } from 'date-fns';
+import { format, parseISO, isValid } from 'date-fns';
 import { ArrowLeft, Plus, DollarSign, Calendar } from 'lucide-react';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
@@ -41,8 +41,16 @@ const InvoiceDetail: React.FC = () => {
   const paymentPlanColumns = [
     {
       header: 'Due Date',
-      accessor: (item: typeof state.paymentPlans[0]) => 
-        format(new Date(item.installmentDate), 'MMM d, yyyy'),
+      accessor: (item: typeof state.paymentPlans[0]) => {
+        const date = typeof item.installmentDate === 'string'
+          ? parseISO(item.installmentDate)
+          : item.installmentDate instanceof Date
+          ? item.installmentDate
+          : null;
+        return date && isValid(date)
+          ? format(date, 'MMM d, yyyy')
+          : 'Invalid Date';
+      },
       sortable: true,
     },
     {
@@ -118,18 +126,36 @@ const InvoiceDetail: React.FC = () => {
                 </span>
               </dd>
             </div>
-            <div>
-              <dt className="text-sm font-medium text-gray-500">Issue Date</dt>
-              <dd className="mt-1 text-sm text-gray-900">
-                {format(new Date(invoice.issueDate), 'MMMM d, yyyy')}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-sm font-medium text-gray-500">Due Date</dt>
-              <dd className="mt-1 text-sm text-gray-900">
-                {format(new Date(invoice.dueDate), 'MMMM d, yyyy')}
-              </dd>
-            </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Issue Date</dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {(() => {
+                    const date = typeof invoice.issueDate === 'string'
+                      ? parseISO(invoice.issueDate)
+                      : invoice.issueDate instanceof Date
+                      ? invoice.issueDate
+                      : null;
+                    return date && isValid(date)
+                      ? format(date, 'MMMM d, yyyy')
+                      : 'Invalid Date';
+                  })()}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Due Date</dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {(() => {
+                    const date = typeof invoice.dueDate === 'string'
+                      ? parseISO(invoice.dueDate)
+                      : invoice.dueDate instanceof Date
+                      ? invoice.dueDate
+                      : null;
+                    return date && isValid(date)
+                      ? format(date, 'MMMM d, yyyy')
+                      : 'Invalid Date';
+                  })()}
+                </dd>
+              </div>
           </dl>
         </Card>
 

--- a/src/components/service-logs/ServiceLogsList.tsx
+++ b/src/components/service-logs/ServiceLogsList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useData } from '../../context/DataContext';
-import { format } from 'date-fns';
+import { format, parseISO, isValid } from 'date-fns';
 import { Plus, Filter, Truck } from 'lucide-react';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
@@ -41,9 +41,21 @@ const ServiceLogsList: React.FC = () => {
   });
 
   // Sort by newest attempt date first
-  const sortedLogs = [...filteredLogs].sort(
-    (a, b) => new Date(b.attemptDate).getTime() - new Date(a.attemptDate).getTime()
-  );
+  const sortedLogs = [...filteredLogs].sort((a, b) => {
+    const dateA = typeof a.attemptDate === 'string'
+      ? parseISO(a.attemptDate)
+      : a.attemptDate instanceof Date
+      ? a.attemptDate
+      : null;
+    const dateB = typeof b.attemptDate === 'string'
+      ? parseISO(b.attemptDate)
+      : b.attemptDate instanceof Date
+      ? b.attemptDate
+      : null;
+    const timeA = dateA && isValid(dateA) ? dateA.getTime() : 0;
+    const timeB = dateB && isValid(dateB) ? dateB.getTime() : 0;
+    return timeB - timeA;
+  });
 
   // Paginate
   const paginatedLogs = sortedLogs.slice(
@@ -114,8 +126,16 @@ const ServiceLogsList: React.FC = () => {
     },
     {
       header: 'Attempt Date',
-      accessor: (item: typeof state.serviceLogs[0]) => 
-        format(new Date(item.attemptDate), 'MMM d, yyyy h:mm a'),
+      accessor: (item: typeof state.serviceLogs[0]) => {
+        const date = typeof item.attemptDate === 'string'
+          ? parseISO(item.attemptDate)
+          : item.attemptDate instanceof Date
+          ? item.attemptDate
+          : null;
+        return date && isValid(date)
+          ? format(date, 'MMM d, yyyy h:mm a')
+          : 'Invalid Date';
+      },
       sortable: false,
     },
     {

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -215,7 +215,7 @@ function Table<T>({
           <tbody className={`bg-white divide-y divide-neutral-200 ${bodyClassName}`}>
             {sortedData.map((item, rowIndex) => (
               <tr
-                key={String(item[keyField])}
+                key={`${String(item[keyField])}-${rowIndex}`}
                 className={getRowStyles(item, rowIndex)}
                 onClick={() => onRowClick && onRowClick(item)}
               >


### PR DESCRIPTION
## Summary
- fix unsafe date parsing in CaseDetail and other components
- ensure table rows use unique keys
- add missing date-fns imports

## Testing
- `npm run lint`
- `npm run test:unit`
