### PR TITLE
Fix CI workflow action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
       run: npm run test:unit
 
     - name: Archive test coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: coverage-report
@@ -58,10 +58,10 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -92,7 +92,7 @@ jobs:
         VITE_SUPABASE_ANON_KEY: 'mock-anon-key'
 
     - name: Archive test artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-screenshots


### PR DESCRIPTION
## Summary
- update workflow to use `actions/checkout@v4`
- update workflow to use `actions/setup-node@v4`
- update workflow to use `actions/upload-artifact@v4`
- ensure cypress artifact paths end with newline

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:unit`
- `npx vitest run --coverage`
