### PR TITLE
fix: Update GitHub Actions to latest versions and Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install dependencies
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install dependencies
@@ -58,12 +58,12 @@ jobs:
     needs: [build, unit-test]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install dependencies


### PR DESCRIPTION
## Summary
Updates GitHub Actions workflow to use latest action versions and Node.js 20, resolving deprecated action warnings that were causing CI failures.

## Changes
- ✅ **actions/checkout@v3** → **@v4** (all 3 jobs)
- ✅ **actions/setup-node@v3** → **@v4** (all 3 jobs)  
- ✅ **node-version: '18'** → **'20'** (all 3 jobs)
- ✅ **actions/upload-artifact@v4** (already fixed)

## Fixes
- Resolves `Missing download info for actions/upload-artifact@v3` error
- Eliminates deprecated action warnings
- Modernizes CI pipeline with latest GitHub Actions

## Testing
- ✅ Unit tests pass locally: `npm run test:unit`
- ✅ Build tested locally: `npm run build`
- ✅ Focused changes - no code modifications

This addresses the CI analysis findings from run #15259603649 with a clean, focused approach.