### PR TITLE
Fix Cypress auth with real Supabase login

### DIFF
--- a/cypress/e2e/efile.cy.ts
+++ b/cypress/e2e/efile.cy.ts
@@ -1,14 +1,9 @@
 describe('E-Filing Flows', () => {
   beforeEach(() => {
-    // Mock Supabase auth for protected routes
-    cy.window().then((win) => {
-      win.localStorage.setItem('supabase.auth.token', JSON.stringify({
-        access_token: 'mock-access-token',
-        refresh_token: 'mock-refresh-token',
-        expires_at: Date.now() + 3600000,
-        user: { id: 'mock-user-id', email: 'test@example.com' }
-      }));
-    });
+    cy.clearLocalStorage();
+
+    // Perform real Supabase authentication
+    cy.loginSupabase();
     
     // Mock authentication
     cy.intercept('POST', '**/v4/il/user/authenticate', {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,35 @@ Cypress.Commands.add('mockEfileToken', () => {
   }));
 });
 
+// Perform real Supabase login using environment credentials
+Cypress.Commands.add('loginSupabase', () => {
+  const url = Cypress.env('SUPABASE_URL');
+  const anonKey = Cypress.env('SUPABASE_ANON_KEY');
+  const email = Cypress.env('TEST_USER_EMAIL');
+  const password = Cypress.env('TEST_USER_PASSWORD');
+
+  if (!url || !email || !password) {
+    throw new Error('Missing Supabase login environment variables');
+  }
+
+  const projectRef = url.replace(/^https?:\/\//, '').split('.')[0];
+  const storageKey = `sb-${projectRef}-auth-token`;
+
+  cy.request({
+    method: 'POST',
+    url: `${url}/auth/v1/token?grant_type=password`,
+    body: { email, password },
+    headers: {
+      apikey: anonKey,
+      'Content-Type': 'application/json'
+    }
+  }).then((response) => {
+    cy.window().then((win) => {
+      win.localStorage.setItem(storageKey, JSON.stringify(response.body));
+    });
+  });
+});
+
 // Mock a file upload by setting the files property
 Cypress.Commands.add('mockFileUpload', (selector, fixture) => {
   cy.fixture(fixture, 'base64').then(fileContent => {


### PR DESCRIPTION
## Summary
- add a Cypress command for authenticating with Supabase using real credentials
- remove auth mocking from efile.cy.ts and login with Supabase before tests

## Testing
- `npm test` *(fails: Xvfb missing)*
- `npm run lint`
