### PR TITLE
Improve data import mapping

### DIFF
--- a/src/components/admin/CSVDataInspector.tsx
+++ b/src/components/admin/CSVDataInspector.tsx
@@ -7,7 +7,7 @@ import { AlertTriangle, Check, Info } from 'lucide-react';
 interface CSVDataInspectorProps {
   file: File;
   onClose: () => void;
-  onImport: (mappedData: any) => void;
+  onImport: (mappedData: any, fileType: string) => void;
 }
 
 const CSVDataInspector: React.FC<CSVDataInspectorProps> = ({ file, onClose, onImport }) => {
@@ -32,6 +32,11 @@ const CSVDataInspector: React.FC<CSVDataInspectorProps> = ({ file, onClose, onIm
     { value: "plaintiff", label: "Plaintiff / Owner" },
     { value: "defendant", label: "Defendant / Tenant" },
     { value: "address", label: "Property Address" },
+    { value: "name", label: "Contact Name" },
+    { value: "email", label: "Email" },
+    { value: "phone", label: "Phone" },
+    { value: "company", label: "Company" },
+    { value: "role", label: "Role" },
     { value: "filingDate", label: "Filing Date" },
     { value: "status", label: "Case Status" },
     { value: "costs", label: "Costs / Fees" },
@@ -160,6 +165,8 @@ const CSVDataInspector: React.FC<CSVDataInspectorProps> = ({ file, onClose, onIm
       fileType = 'complaint';
     } else if (headers.some(h => h.toLowerCase().includes('court') || h.toLowerCase().includes('hearing'))) {
       fileType = 'hearing';
+    } else if (headers.some(h => h.toLowerCase().includes('email') || h.toLowerCase().includes('phone'))) {
+      fileType = 'contact';
     }
     
     setFileType(fileType);
@@ -174,13 +181,24 @@ const CSVDataInspector: React.FC<CSVDataInspectorProps> = ({ file, onClose, onIm
       if (detectedFields.plaintiff) initialMappings[detectedFields.plaintiff] = 'plaintiff';
       if (detectedFields.defendant) initialMappings[detectedFields.defendant] = 'defendant';
       if (detectedFields.address) initialMappings[detectedFields.address] = 'address';
-      
+
       // Map cost fields
       if (detectedFields.costs) {
         detectedFields.costs.forEach((col: string) => {
           initialMappings[col] = 'costs';
         });
       }
+    } else if (fileType === 'contact') {
+      headers.forEach(h => {
+        const lower = h.toLowerCase();
+        if (lower.includes('name')) initialMappings[h] = 'name';
+        if (lower.includes('email')) initialMappings[h] = 'email';
+        if (lower.includes('phone')) initialMappings[h] = 'phone';
+        if (lower.includes('company')) initialMappings[h] = 'company';
+        if (lower.includes('role')) initialMappings[h] = 'role';
+        if (lower.includes('address')) initialMappings[h] = 'address';
+        if (lower.includes('note')) initialMappings[h] = 'notes';
+      });
     }
     
     setFieldMappings(initialMappings);
@@ -234,7 +252,7 @@ const CSVDataInspector: React.FC<CSVDataInspectorProps> = ({ file, onClose, onIm
     
     console.log(`Mapped ${validMappedData.length} valid rows out of ${mappedData.length} total rows`);
     
-    onImport(validMappedData);
+    onImport(validMappedData, fileType);
   };
 
   return (
@@ -263,6 +281,7 @@ const CSVDataInspector: React.FC<CSVDataInspectorProps> = ({ file, onClose, onIm
                   {fileType === 'all_evictions_files' && 'All Evictions Files format detected'}
                   {fileType === 'complaint' && 'Complaint data format detected'}
                   {fileType === 'hearing' && 'Hearing data format detected'}
+                  {fileType === 'contact' && 'Contact data format detected'}
                   {fileType === 'unknown' && 'Unknown data format - please manually map columns'}
                 </p>
                 <p className="text-xs text-blue-600 mt-1">

--- a/src/components/admin/DataImportTool.tsx
+++ b/src/components/admin/DataImportTool.tsx
@@ -48,8 +48,12 @@ const DataImportTool: React.FC = () => {
     }
 
     // Validate file types
-    if (importType === 'excel' && !selectedFiles[0].name.endsWith('.xlsx')) {
+    if (importType === 'excel' && !selectedFiles[0].name.toLowerCase().endsWith('.xlsx')) {
       setError('Please upload an Excel file (.xlsx)');
+      return;
+    }
+    if (importType === 'csv' && !selectedFiles[0].name.toLowerCase().endsWith('.csv')) {
+      setError('Please upload a CSV file (.csv)');
       return;
     }
 
@@ -59,7 +63,7 @@ const DataImportTool: React.FC = () => {
       if (importType === 'excel') {
         setStep('preview');
         setIsImporting(true);
-        const result = await importFromExcel(selectedFiles[0]);
+        const result = await importFromExcel(selectedFiles);
         setImportResult(result);
         setIsImporting(false);
         
@@ -81,7 +85,7 @@ const DataImportTool: React.FC = () => {
     }
   };
 
-  const handleCsvImportComplete = async (mappedData: any) => {
+  const handleCsvImportComplete = async (mappedData: any, fileType: string) => {
     setIsImporting(true);
     
     try {
@@ -90,12 +94,12 @@ const DataImportTool: React.FC = () => {
       const result = {
         success: true,
         entities: {
-          cases: mappedData, // Use the mapped data that CSVDataInspector provides
-          hearings: [],
+          cases: fileType === 'case' ? mappedData : [],
+          hearings: fileType === 'hearing' ? mappedData : [],
           documents: [],
           invoices: [],
           paymentPlans: [],
-          contacts: [],
+          contacts: fileType === 'contact' ? mappedData : [],
           serviceLogs: [],
         },
         errors: [],

--- a/src/components/admin/RefineImportTool.tsx
+++ b/src/components/admin/RefineImportTool.tsx
@@ -206,7 +206,7 @@ const RefineImportTool: React.FC = () => {
         // Use our existing importers based on the file type
         if (fileImportType === 'excel') {
           console.log("Using Excel importer with file:", file);
-          result = await importFromExcel(file);
+          result = await importFromExcel(Array.isArray(file) ? file : [file]);
         } else {
           // For CSV, we need to handle multiple files
           // First, ensure we have an array of files

--- a/src/utils/dataImport/clientsParser.ts
+++ b/src/utils/dataImport/clientsParser.ts
@@ -119,16 +119,22 @@ export function parseClients(pmData: any[]): Contact[] {
         }
       }
       
-      // Format email
+      // Format additional fields
       const email = formatStringValue(row['E-mail Address'] || '');
-      
+      const contactName = formatStringValue(row['Contact Name'] || companyName);
+      const address = formatStringValue(row['Address'] || '');
+      const notes = formatStringValue(row['Notes'] || '');
+
       // Create contact object
       const contact: Contact = {
         contactId: uuidv4(),
-        name: companyName,
+        name: contactName,
         role: role,
         email: email,
         phone: phone,
+        company: companyName,
+        address: address,
+        notes: notes,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };

--- a/src/utils/dataImport/csvImporter.ts
+++ b/src/utils/dataImport/csvImporter.ts
@@ -203,8 +203,12 @@ export async function importFromCSV(files: File[]): Promise<ImportResult> {
         // Transform the parsed data to match our expected format
         const transformedData = csvFieldMapper.transformDataset(parsedData.data, sheetName);
         
-        // Store transformed data
-        allSheets[sheetName] = transformedData;
+        // Store transformed data, merging if sheet already exists
+        if (allSheets[sheetName]) {
+          allSheets[sheetName] = [...allSheets[sheetName], ...transformedData];
+        } else {
+          allSheets[sheetName] = transformedData;
+        }
         result.stats.processedFiles++;
         result.stats.processedRows += transformedData.length;
         


### PR DESCRIPTION
## Summary
- fix Excel importer invocation and validate CSV file extensions
- support contact files in CSV inspector
- return mapped data per file type
- merge CSV rows across multiple uploads
- parse more contact fields

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
