### PR TITLE
Fix contacts CSV parsing and import path

### DIFF
--- a/src/components/admin/DataImportTool.tsx
+++ b/src/components/admin/DataImportTool.tsx
@@ -82,11 +82,11 @@ const DataImportTool: React.FC = () => {
     }
   };
 
-  const handleCsvImportComplete = async (mappedData: any, fileType: string) => {
+  const handleCsvImportComplete = async (mappedData: any, fileType?: string) => {
     setIsImporting(true);
-    
+
     try {
-      // Use user-selected data type if not auto, otherwise use detected file type
+      // Respect the user's selected data type when provided
       const effectiveDataType = dataType === 'auto' ? fileType : dataType;
       
       // Process the mapped data instead of re-importing the original file


### PR DESCRIPTION
## Summary
- add `parseCsv` helper using PapaParse
- respect selected type when handling CSV import

## Testing
- `npm run lint`
- `npm test` *(fails: Connection timeout / Unexpected error)*