### PR TITLE
Consolidate admin import components

### DIFF
--- a/src/components/admin/DataImportPage.tsx
+++ b/src/components/admin/DataImportPage.tsx
@@ -1,12 +1,8 @@
-import React, { useState } from 'react';
+// DEPRECATED: replaced by DataImportTool.tsx — remove after migration
+import React from 'react';
 import MainLayout from '../layout/MainLayout';
-import Card from '../ui/Card';
-import Button from '../ui/Button';
-import Input from '../ui/Input';
-import Select from '../ui/Select';
-import SimpleImportTool from './SimpleImportTool';
-import EnhancedDataImporter from './EnhancedDataImporter';
 import ErrorBoundary from '../ui/ErrorBoundary';
+import DataImportTool from './DataImportTool';
 
 /**
  * Data Import Page
@@ -16,94 +12,12 @@ import ErrorBoundary from '../ui/ErrorBoundary';
  * - EnhancedDataImporter: Advanced import with field mapping for custom CSV formats
  */
 const DataImportPage: React.FC = () => {
-  const [selectedImporter, setSelectedImporter] = useState<'simple' | 'enhanced' | null>(null);
-
   return (
     <MainLayout>
       <div className="container mx-auto py-6 px-4">
         <h1 className="text-2xl font-bold mb-6">Data Import</h1>
         <ErrorBoundary>
-          {/* Tool Selection */}
-          {!selectedImporter && (
-            <Card className="max-w-4xl mx-auto p-6">
-              <h2 className="text-xl font-semibold mb-4">Select Import Method</h2>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {/* Simple Import Tool */}
-                <Card className="p-6 border hover:border-blue-500 cursor-pointer transition-colors"
-                  onClick={() => setSelectedImporter('simple')}>
-                  <h3 className="text-lg font-medium mb-2">Standard Import</h3>
-                  <p className="text-gray-600 mb-4">
-                    Basic import tool for standard-formatted files that match our system's expected structure.
-                  </p>
-                  <ul className="list-disc list-inside text-sm text-gray-500 mb-4">
-                    <li>For simple data imports</li>
-                    <li>Works with standard file formats</li>
-                    <li>Quick and straightforward</li>
-                  </ul>
-                  <div className="pt-2">
-                    <Button
-                      className="w-full"
-                      onClick={(e) => {
-                        e.stopPropagation(); // Prevent double click event
-                        setSelectedImporter('simple');
-                      }}
-                    >
-                      Use Standard Import
-                    </Button>
-                  </div>
-                </Card>
-                
-                {/* Enhanced Import Tool */}
-                <Card className="p-6 border hover:border-blue-500 cursor-pointer transition-colors"
-                  onClick={() => setSelectedImporter('enhanced')}>
-                  <h3 className="text-lg font-medium mb-2">Enhanced Import</h3>
-                  <p className="text-gray-600 mb-4">
-                    Advanced import tool with field mapping for custom file formats and more detailed controls.
-                  </p>
-                  <ul className="list-disc list-inside text-sm text-gray-500 mb-4">
-                    <li>For custom formatted files</li>
-                    <li>Supports field mapping and transformation</li>
-                    <li>Better handling of non-standard data</li>
-                  </ul>
-                  <div className="pt-2">
-                    <Button
-                      className="w-full"
-                      onClick={(e) => {
-                        e.stopPropagation(); // Prevent double click event
-                        setSelectedImporter('enhanced');
-                      }}
-                    >
-                      Use Enhanced Import
-                    </Button>
-                  </div>
-                </Card>
-              </div>
-            </Card>
-          )}
-          
-          {/* Render the selected import tool */}
-          {selectedImporter === 'simple' && (
-            <ErrorBoundary>
-              <div className="mb-4">
-                <Button onClick={() => setSelectedImporter(null)} variant="outline">
-                  ← Back to Selection
-                </Button>
-              </div>
-              <SimpleImportTool />
-            </ErrorBoundary>
-          )}
-          
-          {selectedImporter === 'enhanced' && (
-            <ErrorBoundary>
-              <div className="mb-4">
-                <Button onClick={() => setSelectedImporter(null)} variant="outline">
-                  ← Back to Selection
-                </Button>
-              </div>
-              <EnhancedDataImporter />
-            </ErrorBoundary>
-          )}
+          <DataImportTool />
         </ErrorBoundary>
       </div>
     </MainLayout>

--- a/src/components/admin/DataImportWrapper.tsx
+++ b/src/components/admin/DataImportWrapper.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED: replaced by DataImportTool.tsx — remove after migration
 import React, { useState } from 'react';
 import Card from '../ui/Card';
 import Button from '../ui/Button';

--- a/src/components/admin/EnhancedDataImporter.tsx
+++ b/src/components/admin/EnhancedDataImporter.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED: replaced by DataImportTool.tsx — remove after migration
 import React, { useState, useEffect } from 'react';
 import { useData } from '../../context/DataContext';
 import Card from '../ui/Card';

--- a/src/components/admin/ImportFormatGuide.tsx
+++ b/src/components/admin/ImportFormatGuide.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED: replaced by DataImportTool.tsx — remove after migration
 import React from 'react';
 import { Dialog, DialogContent, DialogOverlay, DialogTitle } from '@radix-ui/react-dialog';
 import Button from '../ui/Button';

--- a/src/components/admin/RefineImportTool.tsx
+++ b/src/components/admin/RefineImportTool.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED: replaced by DataImportTool.tsx — remove after migration
 import React, { useState } from 'react';
 import { useImport } from '@refinedev/core';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/components/admin/SimpleImportTool.tsx
+++ b/src/components/admin/SimpleImportTool.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED: replaced by DataImportTool.tsx — remove after migration
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { 


### PR DESCRIPTION
## Summary
- deprecate older admin import components
- simplify DataImportPage to render DataImportTool only
- rely on centralized csvParser/routeImport utilities
- drop legacy CSV inspector path in DataImportTool

## Testing
- `npx vitest run`