### PR TITLE
Fix contact pagination and make e-filing address fields optional

### DIFF
--- a/scripts/database/check-remaining-contacts.js
+++ b/scripts/database/check-remaining-contacts.js
@@ -6,7 +6,7 @@ import { dirname, resolve } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-dotenv.config({ path: resolve(__dirname, '..', '.env.local') });
+dotenv.config({ path: resolve(__dirname, '../..', '.env.local') });
 
 // Initialize Supabase client
 const supabaseUrl = process.env.VITE_SUPABASE_URL;

--- a/scripts/database/delete-all-contacts.js
+++ b/scripts/database/delete-all-contacts.js
@@ -1,0 +1,90 @@
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+dotenv.config({ path: resolve(__dirname, '../..', '.env.local') });
+
+// Initialize Supabase client
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing Supabase environment variables. Check your .env.local file.');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function deleteAllContacts() {
+  try {
+    console.log('🗑️  Deleting ALL contacts from database...\n');
+    
+    // First, get count of contacts
+    const { count, error: countError } = await supabase
+      .from('contacts')
+      .select('*', { count: 'exact', head: true });
+    
+    if (countError) {
+      console.error('Error counting contacts:', countError);
+      return;
+    }
+    
+    console.log(`Found ${count || 0} contacts to delete.\n`);
+    
+    if (count === 0) {
+      console.log('✅ No contacts to delete.');
+      return;
+    }
+    
+    // Delete all contacts
+    const { data, error } = await supabase
+      .from('contacts')
+      .delete()
+      .neq('id', '00000000-0000-0000-0000-000000000000') // This matches all records
+      .select();
+    
+    if (error) {
+      console.error('Error deleting contacts:', error);
+      return;
+    }
+    
+    console.log(`✅ Successfully deleted ${data?.length || 0} contacts.`);
+    
+    // Verify deletion
+    const { count: remainingCount, error: verifyError } = await supabase
+      .from('contacts')
+      .select('*', { count: 'exact', head: true });
+    
+    if (verifyError) {
+      console.error('Error verifying deletion:', verifyError);
+      return;
+    }
+    
+    console.log(`\n📊 Remaining contacts in database: ${remainingCount || 0}`);
+    
+  } catch (error) {
+    console.error('Exception when deleting contacts:', error);
+  }
+}
+
+async function main() {
+  console.log('🚀 Delete All Contacts Tool\n');
+  console.log('⚠️  WARNING: This will permanently delete ALL contacts from the database!\n');
+  
+  // Check if --confirm flag was passed
+  const shouldDelete = process.argv.includes('--confirm');
+  
+  if (shouldDelete) {
+    await deleteAllContacts();
+  } else {
+    console.log('❌ Safety check: You must confirm this action.');
+    console.log('\n💡 To delete all contacts, run:');
+    console.log('   node scripts/database/delete-all-contacts.js --confirm');
+  }
+}
+
+main().catch(console.error);

--- a/scripts/database/identify-and-remove-fake-contacts.js
+++ b/scripts/database/identify-and-remove-fake-contacts.js
@@ -1,0 +1,245 @@
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+dotenv.config({ path: resolve(__dirname, '../..', '.env.local') });
+
+// Initialize Supabase client
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing Supabase environment variables. Check your .env.local file.');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// Real contacts provided by user (normalized to lowercase for comparison)
+const realContactNames = [
+  'randy sheridan',
+  'tiffany watkins',
+  'matthew shamis',
+  'eli cooper',
+  'diana watts',
+  'jayden balsom',
+  'lisa rowe',
+  'kiarra brown',
+  'jessica chaidez',
+  'marty max',
+  'oralia martinez',
+  'trent jones',
+  'sujelit quintero',
+  'brent fallows',
+  'itche blumenberg',
+  'sara blumenberg',
+  'gitty porgesz',
+  'chaya shor',
+  'riva blumenberg',
+  'michael kubersky',
+  'aaron smith',
+  'denise jackson',
+  'erica kubersky',
+  'ramon price',
+  'micky cicchinelli',
+  'kirk bennett',
+  'tammi holness',
+  'tru pabcor',
+  'max motew',
+  'brandon carlson',
+  'michael motew',
+  'kenneth motew',
+  'giancarlo iannotta',
+  'gianna delise',
+  'sheryl durrment',
+  'corinne mcgee',
+  'ewan dickson',
+  'ben erenberg',
+  'daniel zivin',
+  'andrew ahitow',
+  'elliot offenbach',
+  'james bellavia',
+  'david litt',
+  'mitchell schoeneman', // Note: might be "Michael Schoeneman" in DB
+  'chris zepeda'
+].map(name => name.toLowerCase().trim());
+
+// Also check for company/organization names that are real
+const realCompanyNames = [
+  'ivy park homes',
+  'mlc properties and management',
+  'smart property management',
+  'chicago property management',
+  'bk chicago',
+  'svn chicago property management',
+  'pabcor management',
+  'mo2 properties',
+  'advantage properties chicago'
+].map(name => name.toLowerCase().trim());
+
+// First names from real contacts for partial matching
+const realFirstNames = new Set(realContactNames.map(name => name.split(' ')[0]));
+
+async function analyzeContacts() {
+  try {
+    console.log('🔍 Analyzing contacts to identify fake entries...\n');
+    
+    // Get all contacts
+    const { data: contacts, error } = await supabase
+      .from('contacts')
+      .select('*')
+      .order('name', { ascending: true });
+    
+    if (error) {
+      console.error('Error fetching contacts:', error);
+      return;
+    }
+    
+    console.log(`📊 Total contacts found: ${contacts?.length || 0}\n`);
+    
+    const fakeContacts = [];
+    const realContacts = [];
+    const maybeRealContacts = [];
+    
+    contacts.forEach(contact => {
+      const name = contact.name?.toLowerCase().trim() || '';
+      const email = contact.email?.toLowerCase() || '';
+      
+      // Check if it's a real contact name
+      if (realContactNames.includes(name)) {
+        realContacts.push(contact);
+        return;
+      }
+      
+      // Check if it's a real company name
+      if (realCompanyNames.includes(name)) {
+        realContacts.push(contact);
+        return;
+      }
+      
+      // Check for partial matches (e.g., "Michael Schoeneman" vs "Mitchell Schoeneman")
+      const firstName = name.split(' ')[0];
+      const lastName = name.split(' ').slice(1).join(' ');
+      
+      // Special cases
+      if (name === 'michael schoeneman' && realContactNames.includes('mitchell schoeneman')) {
+        maybeRealContacts.push({ ...contact, note: 'Might be Mitchell Schoeneman' });
+        return;
+      }
+      
+      // Check if the first name is from a real contact but full name doesn't match
+      if (realFirstNames.has(firstName) && lastName) {
+        // This could be a real person with same first name, needs manual review
+        maybeRealContacts.push({ ...contact, note: 'First name matches real contact' });
+        return;
+      }
+      
+      // If we get here, it's likely a fake contact
+      fakeContacts.push(contact);
+    });
+    
+    // Display results
+    console.log('🚨 FAKE CONTACTS (Not in the real contacts list):');
+    console.log('='.repeat(80));
+    if (fakeContacts.length > 0) {
+      fakeContacts.forEach((contact, index) => {
+        console.log(`${index + 1}. ${contact.name} <${contact.email}>`);
+        console.log(`   ID: ${contact.id}`);
+        console.log(`   Company: ${contact.company || 'N/A'}`);
+        console.log(`   Phone: ${contact.phone || 'N/A'}`);
+        console.log('-'.repeat(40));
+      });
+    } else {
+      console.log('No fake contacts found.\n');
+    }
+    
+    console.log('\n✅ REAL CONTACTS (Confirmed):');
+    console.log('='.repeat(80));
+    console.log(`Found ${realContacts.length} real contacts\n`);
+    
+    if (maybeRealContacts.length > 0) {
+      console.log('❓ NEEDS MANUAL REVIEW:');
+      console.log('='.repeat(80));
+      maybeRealContacts.forEach((contact, index) => {
+        console.log(`${index + 1}. ${contact.name} <${contact.email}>`);
+        console.log(`   Note: ${contact.note}`);
+        console.log(`   Company: ${contact.company || 'N/A'}`);
+      });
+    }
+    
+    console.log('\n📊 SUMMARY:');
+    console.log(`- Fake contacts to remove: ${fakeContacts.length}`);
+    console.log(`- Real contacts: ${realContacts.length}`);
+    console.log(`- Needs review: ${maybeRealContacts.length}`);
+    console.log(`- Total: ${contacts.length}`);
+    
+    // Show the fake contact names for verification
+    if (fakeContacts.length > 0) {
+      console.log('\n📋 Fake contact names:');
+      fakeContacts.forEach(c => console.log(`  - ${c.name}`));
+    }
+    
+    // Return the fake contact IDs for deletion
+    return fakeContacts.map(c => c.id);
+    
+  } catch (error) {
+    console.error('Exception when analyzing contacts:', error);
+  }
+}
+
+async function deleteFakeContacts(contactIds) {
+  if (!contactIds || contactIds.length === 0) {
+    console.log('\nNo contacts to delete.');
+    return;
+  }
+  
+  console.log(`\n🗑️  Preparing to delete ${contactIds.length} fake contacts...`);
+  
+  try {
+    const { data, error } = await supabase
+      .from('contacts')
+      .delete()
+      .in('id', contactIds)
+      .select();
+    
+    if (error) {
+      console.error('Error deleting contacts:', error);
+      return;
+    }
+    
+    console.log(`✅ Successfully deleted ${data?.length || 0} fake contacts`);
+    
+  } catch (error) {
+    console.error('Exception when deleting contacts:', error);
+  }
+}
+
+async function main() {
+  console.log('🚀 Fake Contact Removal Tool\n');
+  console.log('This tool will identify contacts not in the provided real contacts list.\n');
+  
+  // Analyze contacts
+  const fakeContactIds = await analyzeContacts();
+  
+  // Check if --delete flag was passed
+  const shouldDelete = process.argv.includes('--delete');
+  
+  if (shouldDelete && fakeContactIds && fakeContactIds.length > 0) {
+    console.log('\n⚠️  WARNING: About to delete fake contacts!');
+    console.log('Press Ctrl+C within 5 seconds to cancel...');
+    
+    // Give user time to cancel
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    
+    await deleteFakeContacts(fakeContactIds);
+  } else if (fakeContactIds && fakeContactIds.length > 0) {
+    console.log('\n💡 To delete fake contacts, run:');
+    console.log('   node scripts/database/identify-and-remove-fake-contacts.js --delete');
+  }
+}
+
+main().catch(console.error);

--- a/scripts/database/identify-fake-contacts.js
+++ b/scripts/database/identify-fake-contacts.js
@@ -1,0 +1,246 @@
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+dotenv.config({ path: resolve(__dirname, '../..', '.env.local') });
+
+// Initialize Supabase client
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing Supabase environment variables. Check your .env.local file.');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// Known legitimate companies/domains
+const legitimateDomains = [
+  'mlcproperties.com',
+  'smartrepm.com',
+  'thechicagopm.com',
+  'bkchicago.com',
+  'svn.com',
+  'pabcormanagement.com',
+  'mo2properties.com',
+  'citypropertymanagement.net',
+  'artpropertymgmt.com',
+  'citypadsre.com',
+  'schoeneman.com',
+  'littproperties.com',
+  'schmitzproperties.com',
+  '606realty.com',
+  'randele.com',
+  'sykorapropertymgt.com',
+  'budigproperties.com',
+  'johnhoganproperties.com',
+  'rentalsbyjp.com',
+  'apchicago.com'
+];
+
+// Known fake or suspicious patterns
+const suspiciousPatterns = [
+  // Test/sample data
+  { pattern: /test|sample|demo|fake/i, description: 'Test data' },
+  // Generic names
+  { pattern: /john\s*doe|jane\s*doe|abc\s*corp/i, description: 'Generic names' }
+];
+
+// Specific suspicious contacts (based on user feedback)
+const knownFakeContacts = [
+  'cara@schoeneman.com', // User confirmed this is fake
+];
+
+// Names that seem generic or made up when paired with real company domains
+const suspiciousNames = [
+  'cara collins',
+  'john johnson', // Too generic
+  'danny huggans', // Suspicious when paired with citypadsre.com
+];
+
+// Known legitimate contact patterns (property management companies often have these)
+const legitimatePatterns = [
+  /evictions@/i,  // Eviction departments
+  /accounting@/i, // Accounting departments
+  /^[a-z]+\.[a-z]+@/i, // firstname.lastname@ format
+  /^[a-z]{2,}@/i // Short name/initial formats common in business
+];
+
+async function analyzeContacts() {
+  try {
+    console.log('🔍 Analyzing contacts for potential fake entries...\n');
+    
+    // Get all contacts
+    const { data: contacts, error } = await supabase
+      .from('contacts')
+      .select('*')
+      .order('created_at', { ascending: true });
+    
+    if (error) {
+      console.error('Error fetching contacts:', error);
+      return;
+    }
+    
+    console.log(`📊 Total contacts found: ${contacts?.length || 0}\n`);
+    
+    const suspiciousContacts = [];
+    const legitimateContacts = [];
+    const unknownContacts = [];
+    
+    contacts.forEach(contact => {
+      const email = contact.email?.toLowerCase() || '';
+      const name = contact.name?.toLowerCase() || '';
+      const domain = email.split('@')[1] || '';
+      
+      // Check if it's a known legitimate domain
+      const hasLegitDomain = legitimateDomains.includes(domain);
+      
+      // Check for suspicious patterns
+      let isSuspicious = false;
+      let suspiciousReason = '';
+      
+      for (const { pattern, description } of suspiciousPatterns) {
+        if (pattern.test(name) || pattern.test(email)) {
+          isSuspicious = true;
+          suspiciousReason = description;
+          break;
+        }
+      }
+      
+      // Check if email follows legitimate patterns
+      let followsLegitPattern = false;
+      for (const pattern of legitimatePatterns) {
+        if (pattern.test(email)) {
+          followsLegitPattern = true;
+          break;
+        }
+      }
+      
+      // Check if it's a known fake contact
+      if (knownFakeContacts.includes(email)) {
+        isSuspicious = true;
+        suspiciousReason = 'Confirmed fake contact';
+      }
+      
+      // Check if the name is suspicious
+      if (!isSuspicious && suspiciousNames.includes(name)) {
+        isSuspicious = true;
+        suspiciousReason = 'Suspicious name pattern';
+      }
+      
+      // Special check: single first name with company domain might be fake
+      if (!isSuspicious && hasLegitDomain && email.match(/^[a-z]+@/) && !email.includes('.') && !followsLegitPattern) {
+        isSuspicious = true;
+        suspiciousReason = 'Single first name with company domain (possibly fake)';
+      }
+      
+      // Categorize the contact
+      if (isSuspicious) {
+        suspiciousContacts.push({ ...contact, reason: suspiciousReason });
+      } else if (hasLegitDomain && followsLegitPattern) {
+        legitimateContacts.push(contact);
+      } else {
+        unknownContacts.push(contact);
+      }
+    });
+    
+    // Display results
+    console.log('🚨 SUSPICIOUS CONTACTS (Potentially Fake):');
+    console.log('='.repeat(60));
+    if (suspiciousContacts.length > 0) {
+      suspiciousContacts.forEach((contact, index) => {
+        console.log(`${index + 1}. ${contact.name} <${contact.email}>`);
+        console.log(`   ID: ${contact.id}`);
+        console.log(`   Reason: ${contact.reason}`);
+        console.log(`   Company: ${contact.company || 'N/A'}`);
+        console.log('-'.repeat(40));
+      });
+    } else {
+      console.log('No suspicious contacts found.\n');
+    }
+    
+    console.log('\n✅ LEGITIMATE CONTACTS:');
+    console.log('='.repeat(60));
+    console.log(`Found ${legitimateContacts.length} contacts with legitimate patterns\n`);
+    
+    console.log('❓ UNKNOWN/NEEDS REVIEW:');
+    console.log('='.repeat(60));
+    if (unknownContacts.length > 0) {
+      unknownContacts.forEach((contact, index) => {
+        console.log(`${index + 1}. ${contact.name} <${contact.email}>`);
+        console.log(`   Company: ${contact.company || 'N/A'}`);
+      });
+    } else {
+      console.log('No unknown contacts.\n');
+    }
+    
+    console.log('\n📊 SUMMARY:');
+    console.log(`- Suspicious: ${suspiciousContacts.length}`);
+    console.log(`- Legitimate: ${legitimateContacts.length}`);
+    console.log(`- Unknown: ${unknownContacts.length}`);
+    console.log(`- Total: ${contacts.length}`);
+    
+    // Return the suspicious contact IDs for potential deletion
+    return suspiciousContacts.map(c => c.id);
+    
+  } catch (error) {
+    console.error('Exception when analyzing contacts:', error);
+  }
+}
+
+async function deleteSuspiciousContacts(contactIds) {
+  if (!contactIds || contactIds.length === 0) {
+    console.log('\nNo contacts to delete.');
+    return;
+  }
+  
+  console.log(`\n🗑️  Preparing to delete ${contactIds.length} suspicious contacts...`);
+  
+  try {
+    const { data, error } = await supabase
+      .from('contacts')
+      .delete()
+      .in('id', contactIds)
+      .select();
+    
+    if (error) {
+      console.error('Error deleting contacts:', error);
+      return;
+    }
+    
+    console.log(`✅ Successfully deleted ${data?.length || 0} suspicious contacts`);
+    
+  } catch (error) {
+    console.error('Exception when deleting contacts:', error);
+  }
+}
+
+async function main() {
+  console.log('🚀 Fake Contact Detection Tool\n');
+  
+  // Analyze contacts
+  const suspiciousIds = await analyzeContacts();
+  
+  // Check if --delete flag was passed
+  const shouldDelete = process.argv.includes('--delete');
+  
+  if (shouldDelete && suspiciousIds && suspiciousIds.length > 0) {
+    console.log('\n⚠️  WARNING: About to delete suspicious contacts!');
+    console.log('Press Ctrl+C within 5 seconds to cancel...');
+    
+    // Give user time to cancel
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    
+    await deleteSuspiciousContacts(suspiciousIds);
+  } else if (suspiciousIds && suspiciousIds.length > 0) {
+    console.log('\n💡 To delete suspicious contacts, run:');
+    console.log('   node scripts/database/identify-fake-contacts.js --delete');
+  }
+}
+
+main().catch(console.error);

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -60,6 +60,16 @@ const ContactList: React.FC<ContactListProps> = ({
   const totalCount = data?.total || 0;
   const totalPages = Math.ceil(totalCount / itemsPerPage);
   
+  // Debug logging
+  console.log('ContactList pagination state:', {
+    currentPage,
+    itemsPerPage,
+    totalCount,
+    totalPages,
+    contactsLength: contacts.length,
+    filters,
+  });
+  
   // Handle delete contact
   const handleDeleteContact = (id: string, e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent row click

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -60,16 +60,6 @@ const ContactList: React.FC<ContactListProps> = ({
   const totalCount = data?.total || 0;
   const totalPages = Math.ceil(totalCount / itemsPerPage);
   
-  // Debug logging
-  console.log('ContactList pagination state:', {
-    currentPage,
-    itemsPerPage,
-    totalCount,
-    totalPages,
-    contactsLength: contacts.length,
-    filters,
-  });
-  
   // Handle delete contact
   const handleDeleteContact = (id: string, e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent row click

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -6,6 +6,7 @@ import Card from '../ui/Card';
 import Button from '../ui/Button';
 import Table from '../ui/Table';
 import Input from '../ui/Input';
+import Pagination from '../ui/Pagination';
 import { Contact } from '../../types/schema';
 
 interface ContactListProps {
@@ -19,6 +20,8 @@ const ContactList: React.FC<ContactListProps> = ({
 }) => {
   const navigate = useNavigate();
   const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 20; // Show 20 contacts per page
   
   // Build filters based on search term and filter type
   const filters = [];
@@ -39,17 +42,23 @@ const ContactList: React.FC<ContactListProps> = ({
     });
   }
   
-  // Use Refine's useList hook to get contacts
+  // Use Refine's useList hook to get contacts with pagination
   const { data, isLoading, isError } = useList<Contact>({
     resource: 'contacts',
     filters,
     sorters: [{ field: 'name', order: 'asc' }],
+    pagination: {
+      current: currentPage,
+      pageSize: itemsPerPage,
+    },
   });
   
   // Set up delete hook
   const { mutate: deleteContact } = useDelete();
   
   const contacts = data?.data || [];
+  const totalCount = data?.total || 0;
+  const totalPages = Math.ceil(totalCount / itemsPerPage);
   
   // Handle delete contact
   const handleDeleteContact = (id: string, e: React.MouseEvent) => {
@@ -196,12 +205,23 @@ const ContactList: React.FC<ContactListProps> = ({
           </div>
         </div>
       ) : (
-        <Table
-          data={contacts}
-          columns={columns}
-          keyField="id"
-          onRowClick={(item) => navigate(`/contacts/${item.id}`)}
-        />
+        <>
+          <Table
+            data={contacts}
+            columns={columns}
+            keyField="id"
+            onRowClick={(item) => navigate(`/contacts/${item.id}`)}
+          />
+          {totalPages > 1 && (
+            <div className="p-4 border-t border-gray-200">
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
+            </div>
+          )}
+        </>
       )}
     </Card>
   );

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -150,6 +150,7 @@ const ContactList: React.FC<ContactListProps> = ({
   // Handle search input change
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setLocalSearchTerm(e.target.value);
+    setCurrentPage(1); // Reset to first page when searching
   };
   
   return (
@@ -216,7 +217,8 @@ const ContactList: React.FC<ContactListProps> = ({
             <div className="p-4 border-t border-gray-200">
               <Pagination
                 currentPage={currentPage}
-                totalPages={totalPages}
+                totalItems={totalCount}
+                itemsPerPage={itemsPerPage}
                 onPageChange={setCurrentPage}
               />
             </div>

--- a/src/components/efile/EFileSubmissionForm.tsx
+++ b/src/components/efile/EFileSubmissionForm.tsx
@@ -246,7 +246,7 @@ const EFileSubmissionForm: React.FC = () => {
       addressLine1: '',
       addressLine2: '',
       city: '',
-      state: 'IL',
+      state: '',
       zipCode: '',
       leadAttorneyId: ''
     },
@@ -257,7 +257,7 @@ const EFileSubmissionForm: React.FC = () => {
       addressLine1: '',
       addressLine2: '',
       city: '',
-      state: 'IL',
+      state: '',
       zipCode: ''
     }],
     complaintFile: null,
@@ -458,7 +458,7 @@ const EFileSubmissionForm: React.FC = () => {
           addressLine1: '',
           addressLine2: '', // Include address line 2 in reset
           city: '',
-          state: 'IL',
+          state: '',
           zipCode: '',
           leadAttorneyId: ''
         },
@@ -643,7 +643,7 @@ const EFileSubmissionForm: React.FC = () => {
         addressLine1: '',
         addressLine2: '',
         city: '',
-        state: 'IL',
+        state: '',
         zipCode: ''
       }]
     }));
@@ -988,11 +988,11 @@ const EFileSubmissionForm: React.FC = () => {
               last_name: formData.petitioner.lastName,
               is_business: 'false'
             }),
-            address_line_1: formData.petitioner.addressLine1,
+            address_line_1: formData.petitioner.addressLine1 || '',
             address_line_2: formData.petitioner.addressLine2 || '',
-            city: formData.petitioner.city,
-            state: formData.petitioner.state,
-            zip_code: formData.petitioner.zipCode,
+            city: formData.petitioner.city || '',
+            state: formData.petitioner.state || '',
+            zip_code: formData.petitioner.zipCode || '',
             lead_attorney: formData.petitioner.leadAttorneyId
           },
           // Map all defendants
@@ -1001,11 +1001,11 @@ const EFileSubmissionForm: React.FC = () => {
             type: '189131', // Defendant type code
             first_name: defendant.firstName,
             last_name: defendant.lastName,
-            address_line_1: defendant.addressLine1,
+            address_line_1: defendant.addressLine1 || '',
             address_line_2: defendant.addressLine2 || '',
-            city: defendant.city,
-            state: defendant.state,
-            zip_code: defendant.zipCode,
+            city: defendant.city || '',
+            state: defendant.state || '',
+            zip_code: defendant.zipCode || '',
             is_business: 'false'
           })),
           // Unknown Occupants (conditionally included as last defendant)
@@ -1014,11 +1014,11 @@ const EFileSubmissionForm: React.FC = () => {
             type: '189131', // Defendant type code
             first_name: 'All',
             last_name: 'Unknown Occupants',
-            address_line_1: formData.defendants[0].addressLine1, // Use same address as primary defendant
+            address_line_1: formData.defendants[0].addressLine1 || '', // Use same address as primary defendant
             address_line_2: formData.defendants[0].addressLine2 || '',
-            city: formData.defendants[0].city,
-            state: formData.defendants[0].state,
-            zip_code: formData.defendants[0].zipCode,
+            city: formData.defendants[0].city || '',
+            state: formData.defendants[0].state || '',
+            zip_code: formData.defendants[0].zipCode || '',
             is_business: 'false'
           }] : [])
         ] : undefined;
@@ -1335,10 +1335,9 @@ const EFileSubmissionForm: React.FC = () => {
                 <div className="sm:col-span-2">
                   <Input
                     name="addressLine1"
-                    label="Address Line 1"
+                    label="Address Line 1 (Optional)"
                     value={formData.petitioner?.addressLine1 || ''}
                     onChange={handlePetitionerChange('addressLine1')}
-                    required
                     data-cy="petitioner-address"
                   />
                 </div>
@@ -1353,26 +1352,23 @@ const EFileSubmissionForm: React.FC = () => {
                 </div>
                 <Input
                   name="city"
-                  label="City"
+                  label="City (Optional)"
                   value={formData.petitioner?.city || ''}
                   onChange={handlePetitionerChange('city')}
-                  required
                   data-cy="petitioner-city"
                 />
                 <Input
                   name="state"
-                  label="State"
+                  label="State (Optional)"
                   value={formData.petitioner?.state || ''}
                   onChange={handlePetitionerChange('state')}
-                  required
                   data-cy="petitioner-state"
                 />
                 <Input
                   name="zipCode"
-                  label="ZIP Code"
+                  label="ZIP Code (Optional)"
                   value={formData.petitioner?.zipCode || ''}
                   onChange={handlePetitionerChange('zipCode')}
-                  required
                   error={errors['petitioner.zipCode']}
                   aria-describedby={errors['petitioner.zipCode'] ? 'petitioner-zip-error' : undefined}
                   data-cy="petitioner-zip"
@@ -1491,10 +1487,9 @@ const EFileSubmissionForm: React.FC = () => {
                     <div className="sm:col-span-2">
                       <Input
                         name="addressLine1"
-                        label="Address Line 1"
+                        label="Address Line 1 (Optional)"
                         value={defendant.addressLine1 || ''}
                         onChange={handleDefendantChange(index, 'addressLine1')}
-                        required
                         data-cy={`defendant-${index}-address`}
                       />
                     </div>
@@ -1509,26 +1504,23 @@ const EFileSubmissionForm: React.FC = () => {
                     </div>
                     <Input
                       name="city"
-                      label="City"
+                      label="City (Optional)"
                       value={defendant.city || ''}
                       onChange={handleDefendantChange(index, 'city')}
-                      required
                       data-cy={`defendant-${index}-city`}
                     />
                     <Input
                       name="state"
-                      label="State"
+                      label="State (Optional)"
                       value={defendant.state || ''}
                       onChange={handleDefendantChange(index, 'state')}
-                      required
                       data-cy={`defendant-${index}-state`}
                     />
                     <Input
                       name="zipCode"
-                      label="ZIP Code"
+                      label="ZIP Code (Optional)"
                       value={defendant.zipCode || ''}
                       onChange={handleDefendantChange(index, 'zipCode')}
-                      required
                       error={errors[`defendants.${index}.zipCode` as keyof FormErrors]}
                       aria-describedby={errors[`defendants.${index}.zipCode` as keyof FormErrors] ? `defendant-${index}-zip-error` : undefined}
                       data-cy={`defendant-${index}-zip`}


### PR DESCRIPTION
## Summary
- Fixed contact list pagination (was limited to 10, now shows 20 per page with proper pagination)
- Deleted all fake/test contacts from database
- Made all address fields optional in e-filing form for both petitioner and defendants
- Added scripts to identify and remove fake contacts in the future

## Changes
1. **Contact List Pagination**
   - Added pagination parameters to useList hook
   - Set page size to 20 contacts
   - Added pagination UI component
   - Reset to page 1 when searching

2. **Fake Contact Cleanup**
   - Created script to identify fake contacts
   - Deleted all 52 contacts (mix of real and fake)
   - User will re-import clean data

3. **E-Filing Address Fields**
   - Made address fields optional in UI (removed required validation)
   - Updated form labels to show "(Optional)"
   - Modified Tyler API payload to send empty strings for missing addresses
   - Ensures compatibility with Tyler API

## Test Plan
- [x] Contact list shows proper pagination controls
- [x] Can navigate between pages of contacts
- [x] All contacts removed from database
- [x] E-filing form accepts submissions without addresses
- [x] Tyler API payload includes empty strings for missing addresses