### PR TITLE
Migrate remaining components to shadcn Card

### DIFF
--- a/src/components/admin/CSVDataInspector.tsx
+++ b/src/components/admin/CSVDataInspector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Papa from 'papaparse';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import { AlertTriangle, Check, Info } from 'lucide-react';
 

--- a/src/components/admin/DataImportPage.tsx
+++ b/src/components/admin/DataImportPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import MainLayout from '../layout/MainLayout';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';

--- a/src/components/admin/DataImportTool.tsx
+++ b/src/components/admin/DataImportTool.tsx
@@ -6,7 +6,7 @@ import { routeImport } from '../../utils/dataImport/importRouter';
 import CSVDataInspector from './CSVDataInspector';
 import { useData } from '../../context/DataContext';
 import { supabase } from '../../lib/supabaseClient';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Select from '../ui/Select';
 import ImportFormatGuide from './ImportFormatGuide';

--- a/src/components/admin/DataImportWrapper.tsx
+++ b/src/components/admin/DataImportWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import SimpleImportTool from './SimpleImportTool';
 import EnhancedDataImporter from './EnhancedDataImporter';

--- a/src/components/admin/EnhancedDataImporter.tsx
+++ b/src/components/admin/EnhancedDataImporter.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useData } from '../../context/DataContext';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';

--- a/src/components/admin/RefineImportTool.tsx
+++ b/src/components/admin/RefineImportTool.tsx
@@ -12,7 +12,7 @@ import {
   Plus,
   Database
 } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Select from '../ui/Select';
 import { useData } from '../../context/DataContext';

--- a/src/components/admin/SimpleImportTool.tsx
+++ b/src/components/admin/SimpleImportTool.tsx
@@ -9,7 +9,7 @@ import {
   Info, 
   Database
 } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Select from '../ui/Select';
 import { useData } from '../../context/DataContext';

--- a/src/components/calendar/CalendarEventForm.tsx
+++ b/src/components/calendar/CalendarEventForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder CalendarEventForm component

--- a/src/components/calendar/CalendarIntegrationForm.tsx
+++ b/src/components/calendar/CalendarIntegrationForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder CalendarIntegrationForm component

--- a/src/components/calendar/CalendarMonthView.tsx
+++ b/src/components/calendar/CalendarMonthView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder CalendarMonthView component

--- a/src/components/cases/CaseFinancialStatus.tsx
+++ b/src/components/cases/CaseFinancialStatus.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { format, parseISO, isValid, differenceInDays } from 'date-fns';
 import { MetricCard, StatusCard, ActionListCard } from '../ui';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import { useData } from '../../context/DataContext';
 import { useInvoices } from '../../hooks/useInvoices';

--- a/src/components/contacts/ContactDetail.tsx
+++ b/src/components/contacts/ContactDetail.tsx
@@ -12,7 +12,7 @@ import {
   Briefcase,
   ArrowLeft
 } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import { Contact } from '../../types/schema';
 import { format, parseISO, isValid } from 'date-fns';

--- a/src/components/contacts/ContactForm.tsx
+++ b/src/components/contacts/ContactForm.tsx
@@ -18,7 +18,7 @@ import {
   ArrowLeft,
   Save
 } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';

--- a/src/components/contacts/ContactList.tsx
+++ b/src/components/contacts/ContactList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useList, useDelete } from '@refinedev/core';
 import { useNavigate } from 'react-router-dom';
 import { Edit, Trash2, Eye, Users, Mail, Phone, Search } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Table from '../ui/Table';
 import Input from '../ui/Input';

--- a/src/components/document-templates/DocumentGenerator.tsx
+++ b/src/components/document-templates/DocumentGenerator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder DocumentGenerator component

--- a/src/components/document-templates/TemplateDetail.tsx
+++ b/src/components/document-templates/TemplateDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder TemplateDetail component

--- a/src/components/document-templates/TemplateList.tsx
+++ b/src/components/document-templates/TemplateList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder TemplateList component

--- a/src/components/documents/DocumentDetail.tsx
+++ b/src/components/documents/DocumentDetail.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Download, Edit, Trash2, FileText, AlertCircle, ExternalLink } from 'lucide-react';
 import { format, parseISO, isValid } from 'date-fns';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import { useDocuments } from '../../hooks/useDocuments';
 import { useToast } from '../../context/ToastContext';

--- a/src/components/documents/DocumentUpload.tsx
+++ b/src/components/documents/DocumentUpload.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Upload, FileText, AlertCircle } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';

--- a/src/components/documents/DocumentUploadForm.tsx
+++ b/src/components/documents/DocumentUploadForm.tsx
@@ -5,7 +5,7 @@ import { supabase } from '../../lib/supabaseClient';
 import { useToast } from '../../context/ToastContext';
 import { createDocument } from '../../hooks/useDocuments';
 import Button from '../ui/Button';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Select from '../ui/Select';
 import Typography from '../ui/Typography';
 

--- a/src/components/efile/EFileDrafts.tsx
+++ b/src/components/efile/EFileDrafts.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useToast } from '@/context/ToastContext';
 import Button from '../ui/Button';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 interface DraftData {
   id: string;

--- a/src/components/efile/EFileSubmissionForm.tsx
+++ b/src/components/efile/EFileSubmissionForm.tsx
@@ -10,7 +10,7 @@ import { EFileSubmission, EFileDocument } from '@/types/efile';
 import Input from '../ui/Input';
 import Select from '../ui/Select';
 import Button from '../ui/Button';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import { ENHANCED_EFILING_PHASE_A, ENHANCED_EFILING_PHASE_B } from '@/config/features';
 import { JURISDICTIONS, type Jurisdiction } from '@/config/jurisdictions';
 import { TYLER_CONFIG } from '@/config/tyler-api';

--- a/src/components/hearings/HearingForm.tsx
+++ b/src/components/hearings/HearingForm.tsx
@@ -8,7 +8,7 @@ import Modal from '../ui/Modal';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import { Calendar, LinkIcon } from 'lucide-react';
 
 interface HearingFormProps {

--- a/src/components/invoices/InvoiceDetail.tsx
+++ b/src/components/invoices/InvoiceDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useData } from '../../context/DataContext';
 import { format, parseISO, isValid } from 'date-fns';
 import { ArrowLeft, Plus } from 'lucide-react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Table from '../ui/Table';
 import InvoiceForm from './InvoiceForm';

--- a/src/components/notifications/NotificationSettingsForm.tsx
+++ b/src/components/notifications/NotificationSettingsForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder NotificationSettingsForm component

--- a/src/components/notifications/NotificationsList.tsx
+++ b/src/components/notifications/NotificationsList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder NotificationsList component

--- a/src/components/templates/PageTemplates.tsx
+++ b/src/components/templates/PageTemplates.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Typography from '../ui/Typography';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';

--- a/src/components/workflows/WorkflowDashboard.tsx
+++ b/src/components/workflows/WorkflowDashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder WorkflowDashboard component

--- a/src/components/workflows/WorkflowDetail.tsx
+++ b/src/components/workflows/WorkflowDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder WorkflowDetail component

--- a/src/components/workflows/WorkflowForm.tsx
+++ b/src/components/workflows/WorkflowForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder WorkflowForm component

--- a/src/components/workflows/WorkflowTaskForm.tsx
+++ b/src/components/workflows/WorkflowTaskForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../ui/Card';
+import { Card } from '../ui/shadcn-card';
 
 /**
  * Placeholder WorkflowTaskForm component


### PR DESCRIPTION
## Summary
- replace deprecated `Card` imports with shadcn Card
- update references across admin, calendar, contacts, documents, e-file and workflows

## Testing
- `npm run lint` *(fails: no-useless-catch in DataImportTool.tsx)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68488ba939548325b41951dc9efeb04d