### PR TITLE
Fix supabase mocks and update UI tests

### DIFF
--- a/tests/unit/api/cases.test.ts
+++ b/tests/unit/api/cases.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createRequest, createResponse } from 'node-mocks-http';
 
-// Create mock function first
-const mockSupabaseRpc = vi.fn();
+// Declare mock function reference
+var mockSupabaseRpc: ReturnType<typeof vi.fn>;
 
 // Mock Supabase
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: vi.fn(() => ({
-    rpc: mockSupabaseRpc,
-  })),
-}));
+vi.mock('@supabase/supabase-js', () => {
+  // Initialize the mock within the factory to avoid TDZ issues
+  mockSupabaseRpc = vi.fn();
+  return {
+    createClient: vi.fn(() => ({
+      rpc: mockSupabaseRpc,
+    })),
+  };
+});
 
 // Import handler after mocking
 import handler from '../../../api/cases.js';

--- a/tests/unit/api/documents.test.ts
+++ b/tests/unit/api/documents.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createRequest, createResponse } from 'node-mocks-http';
 
-// Create mock function first
-const mockSupabaseRpc = vi.fn();
+// Declare mock function reference
+var mockSupabaseRpc: ReturnType<typeof vi.fn>;
 
 // Mock Supabase
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: vi.fn(() => ({
-    rpc: mockSupabaseRpc,
-  })),
-}));
+vi.mock('@supabase/supabase-js', () => {
+  // Initialize the mock within the factory to avoid TDZ issues
+  mockSupabaseRpc = vi.fn();
+  return {
+    createClient: vi.fn(() => ({
+      rpc: mockSupabaseRpc,
+    })),
+  };
+});
 
 // Import handler after mocking
 import handler from '../../../api/documents.js';

--- a/tests/unit/components/ui/DataTable.test.tsx
+++ b/tests/unit/components/ui/DataTable.test.tsx
@@ -86,8 +86,8 @@ describe('DataTable', () => {
 
     it('renders loading state', () => {
       render(<DataTable data={[]} columns={columns} isLoading />);
-      
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+      expect(screen.getByText('Loading data...')).toBeInTheDocument();
     });
 
     it('renders error state', () => {
@@ -137,15 +137,16 @@ describe('DataTable', () => {
       render(<DataTable data={mockData} columns={columns} />);
       
       const nameHeader = screen.getByRole('columnheader', { name: /^Name$/ });
-      await userEvent.click(nameHeader);
-      
-      // Should show ascending indicator
-      expect(nameHeader.closest('th')).toHaveTextContent('▲');
-      
-      await userEvent.click(nameHeader);
-      
-      // Should show descending indicator
-      expect(nameHeader.closest('th')).toHaveTextContent('▼');
+      const clickable = nameHeader.querySelector('div')!;
+      await userEvent.click(clickable);
+
+      // Should show ascending indicator icon
+      expect(nameHeader.querySelector('svg.lucide-chevron-up')).toBeInTheDocument();
+
+      await userEvent.click(clickable);
+
+      // Should show descending indicator icon
+      expect(nameHeader.querySelector('svg.lucide-chevron-down')).toBeInTheDocument();
     });
   });
 
@@ -153,7 +154,7 @@ describe('DataTable', () => {
     it('filters by text input', async () => {
       render(<DataTable data={mockData} columns={columns} />);
       
-      const textFilter = screen.getByPlaceholderText('Filter Name...');
+      const textFilter = screen.getByPlaceholderText('Search name...');
       
       await userEvent.type(textFilter, 'Test');
       
@@ -181,7 +182,7 @@ describe('DataTable', () => {
     it('clears filters when clear button is clicked', async () => {
       render(<DataTable data={mockData} columns={columns} />);
       
-      const textFilter = screen.getByPlaceholderText('Filter Name...');
+      const textFilter = screen.getByPlaceholderText('Search name...');
       await userEvent.type(textFilter, 'Test');
       
       await waitFor(() => {
@@ -388,7 +389,7 @@ describe('DataTable', () => {
       render(<DataTable data={mockData} columns={columns} />);
       
       // Apply filter
-      const textFilter = screen.getByPlaceholderText('Filter Name...');
+      const textFilter = screen.getByPlaceholderText('Search name...');
       await userEvent.type(textFilter, 'Item');
       
       await waitFor(() => {

--- a/tests/unit/components/ui/DateRangeFilter.test.tsx
+++ b/tests/unit/components/ui/DateRangeFilter.test.tsx
@@ -27,16 +27,16 @@ describe('DateRangeFilter', () => {
     const column = createMockColumn();
     render(<DateRangeFilter column={column} />);
     
-    expect(screen.getByLabelText('Start date')).toBeInTheDocument();
-    expect(screen.getByLabelText('End date')).toBeInTheDocument();
+    expect(screen.getByLabelText('Start date for dateColumn filter')).toBeInTheDocument();
+    expect(screen.getByLabelText('End date for dateColumn filter')).toBeInTheDocument();
   });
 
   it('displays current filter values', () => {
     const column = createMockColumn(['2024-03-01', '2024-03-31']);
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     expect(startInput).toHaveValue('2024-03-01');
     expect(endInput).toHaveValue('2024-03-31');
@@ -47,7 +47,7 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
     await user.type(startInput, '2024-05-15');
     
     await waitFor(() => {
@@ -60,7 +60,7 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const endInput = screen.getByLabelText('End date');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     await user.type(endInput, '2024-06-30');
     
     await waitFor(() => {
@@ -73,8 +73,8 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     await user.type(startInput, '2024-01-01');
     await user.type(endInput, '2024-12-31');
@@ -89,8 +89,8 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     await user.clear(startInput);
     await user.clear(endInput);
@@ -104,8 +104,8 @@ describe('DateRangeFilter', () => {
     const column = createMockColumn();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     expect(startInput).toHaveAttribute('min', '2024-01-01');
     expect(startInput).toHaveAttribute('max', '2024-12-31');
@@ -118,8 +118,8 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     await user.type(startInput, '2024-06-01');
     await user.type(endInput, '2024-05-01');
@@ -133,7 +133,7 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
     
     // Try to input invalid date
     await user.type(startInput, 'invalid-date');
@@ -147,7 +147,7 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
     
     // Only set start date
     await user.type(startInput, '2024-07-01');
@@ -162,7 +162,7 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
     
     // Click to open date picker
     await user.click(startInput);
@@ -182,8 +182,8 @@ describe('DateRangeFilter', () => {
     const column = createMockColumn();
     const { rerender } = render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     expect(startInput).toHaveValue('');
     expect(endInput).toHaveValue('');
@@ -201,8 +201,8 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     // Tab between inputs
     await user.click(startInput);
@@ -215,21 +215,21 @@ describe('DateRangeFilter', () => {
     const column = createMockColumn();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     expect(startInput).toHaveAttribute('type', 'date');
     expect(endInput).toHaveAttribute('type', 'date');
-    expect(startInput).toHaveAttribute('aria-label', expect.stringContaining('Start date'));
-    expect(endInput).toHaveAttribute('aria-label', expect.stringContaining('End date'));
+    expect(startInput).toHaveAttribute('aria-label', expect.stringContaining('Start date for dateColumn filter'));
+    expect(endInput).toHaveAttribute('aria-label', expect.stringContaining('End date for dateColumn filter'));
   });
 
   it('shows date format placeholder', () => {
     const column = createMockColumn();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     // Date inputs should have proper placeholders
     expect(startInput).toHaveAttribute('placeholder', 'yyyy-mm-dd');
@@ -241,7 +241,7 @@ describe('DateRangeFilter', () => {
     const user = userEvent.setup();
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
     
     // Input date in ISO format
     await user.type(startInput, '2024-09-15');
@@ -257,8 +257,8 @@ describe('DateRangeFilter', () => {
     
     render(<DateRangeFilter column={column} />);
     
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
+    const startInput = screen.getByLabelText('Start date for dateColumn filter');
+    const endInput = screen.getByLabelText('End date for dateColumn filter');
     
     // Should not have min/max when faceted values are undefined
     expect(startInput).not.toHaveAttribute('min');

--- a/tests/unit/components/ui/TextFilter.test.tsx
+++ b/tests/unit/components/ui/TextFilter.test.tsx
@@ -46,7 +46,7 @@ describe('TextFilter', () => {
     const user = userEvent.setup();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     await user.type(input, 'search term');
     
     // Debounced, so we need to wait
@@ -60,7 +60,7 @@ describe('TextFilter', () => {
     const user = userEvent.setup();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     
     // Type quickly
     await user.type(input, 'abc');
@@ -80,7 +80,7 @@ describe('TextFilter', () => {
     const user = userEvent.setup();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     
     // Clear the input
     await user.clear(input);
@@ -108,7 +108,7 @@ describe('TextFilter', () => {
     const user = userEvent.setup();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     await user.type(input, 'test@example.com');
     
     await waitFor(() => {
@@ -120,7 +120,7 @@ describe('TextFilter', () => {
     const column = createMockColumn('preserved value');
     const { rerender } = render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     expect(input).toHaveValue('preserved value');
     
     // Re-render with same value
@@ -132,7 +132,7 @@ describe('TextFilter', () => {
     const column = createMockColumn('initial');
     const { rerender } = render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     expect(input).toHaveValue('initial');
     
     // Update column filter value
@@ -147,7 +147,7 @@ describe('TextFilter', () => {
     const user = userEvent.setup();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     
     // Simulate paste
     await user.click(input);
@@ -163,7 +163,7 @@ describe('TextFilter', () => {
     const user = userEvent.setup();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     await user.type(input, '  trimmed  ');
     
     await waitFor(() => {
@@ -182,7 +182,7 @@ describe('TextFilter', () => {
     const column = createMockColumn();
     render(<TextFilter column={column} />);
     
-    const input = screen.getByPlaceholderText('Filter Test Column...');
+    const input = screen.getByPlaceholderText('Search testColumn...');
     expect(input).toHaveAttribute('type', 'text');
     expect(input).toHaveAttribute('aria-label', expect.stringContaining('Filter'));
   });


### PR DESCRIPTION
## Summary
- fix supabase mock initialization in API tests
- adjust DataTable tests to match component text
- update TextFilter and DateRangeFilter placeholders
- update sort indicator expectations

## Testing
- `npx vitest run --reporter=basic` *(fails: Test Files 3 failed | 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c55073a4883258ea27bbdb9e04706