### PR TITLE
Fix multi-agent tool ESM imports

### DIFF
--- a/agent.ts
+++ b/agent.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import * as readline from 'readline';
-import { CodeEditOrchestrator, CodeEditTask } from './dev-tools/multi-agent/index';
+import { CodeEditOrchestrator, CodeEditTask } from './dev-tools/multi-agent/index.js';
 
 // Interactive agent that accepts custom prompts like Claude
 const rl = readline.createInterface({

--- a/dev-tools/multi-agent/index.ts
+++ b/dev-tools/multi-agent/index.ts
@@ -1,8 +1,8 @@
-export { CodeEditOrchestrator } from './CodeEditOrchestrator';
-export * from './types';
-export * from './agents/FileAnalysisAgent';
-export * from './agents/RefactorAgent';
-export * from './agents/TestAgent';
-export * from './agents/DocumentationAgent';
-export * from './agents/StyleAgent';
-export * from './agents/ValidationAgent';
+export { CodeEditOrchestrator } from './CodeEditOrchestrator.js';
+export * from './types.js';
+export * from './agents/FileAnalysisAgent.js';
+export * from './agents/RefactorAgent.js';
+export * from './agents/TestAgent.js';
+export * from './agents/DocumentationAgent.js';
+export * from './agents/StyleAgent.js';
+export * from './agents/ValidationAgent.js';

--- a/refactor.ts
+++ b/refactor.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { CodeEditOrchestrator, CodeEditTask } from './dev-tools/multi-agent/index';
+import { CodeEditOrchestrator, CodeEditTask } from './dev-tools/multi-agent/index.js';
 
 // This file lets you run multi-agent refactoring from the project root
 // Usage: npx ts-node refactor.ts <command> [options]


### PR DESCRIPTION
## Summary
- ensure multi-agent exports resolve to `.js`
- update top-level scripts to import the new ESM entry

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_684fa10748bc8325bc09cf69ff840fcf