### PR TITLE
Optimize build and lazy load pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <meta property="twitter:description" content="Professional legal case management system for law firms. Manage cases, documents, hearings, and client communications efficiently." />
     <meta property="twitter:image" content="/wszmainlogo.webp" />
     <!-- Critical resource preloads -->
-    <link rel="preload" href="/wszmainlogo.webp" as="image" type="image/webp">
+    <link rel="preload" href="/wszmainlogo.webp" as="image" type="image/webp" fetchpriority="high">
     <link rel="preload" href="/src/index.css" as="style">
     <link rel="preload" href="/src/main.tsx" as="script">
     

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,26 +21,26 @@ import CaseSkeleton from './components/cases/CaseSkeleton';
 import HearingsPage from './components/hearings/HearingsPage';
 import HearingForm from './components/hearings/HearingForm';
 const DocumentList = React.lazy(() => import('./components/documents/DocumentList'));
-import DocumentManagement from './components/documents/DocumentManagement';
-import DocumentUploadForm from './components/documents/DocumentUploadForm';
-import DocumentDetail from './components/documents/DocumentDetail';
-import InvoicesPage from './components/invoices/InvoicesPage';
-import InvoiceDetail from './components/invoices/InvoiceDetail';
-import ServiceLogsList from './components/service-logs/ServiceLogsList';
-import EFilePage from './components/efile/EFilePage';
-import AdminPage from './components/admin/AdminPage';
-import WorkflowDashboard from './components/workflows/WorkflowDashboard';
-import WorkflowDetail from './components/workflows/WorkflowDetail';
-import TemplateList from './components/document-templates/TemplateList';
-import TemplateDetail from './components/document-templates/TemplateDetail';
-import DocumentGenerator from './components/document-templates/DocumentGenerator';
-import CalendarPage from './components/calendar/CalendarPage';
-import NotificationsPage from './components/notifications/NotificationsPage';
-import NotificationScheduler from './components/notifications/NotificationScheduler';
-import ContactsPage from './components/contacts/ContactsPage';
-import ActivityPage from './components/activity/ActivityPage';
-import ProfilePage from './components/user/ProfilePage';
-import SettingsPage from './components/user/SettingsPage';
+const DocumentManagement = React.lazy(() => import('./components/documents/DocumentManagement'));
+const DocumentUploadForm = React.lazy(() => import('./components/documents/DocumentUploadForm'));
+const DocumentDetail = React.lazy(() => import('./components/documents/DocumentDetail'));
+const InvoicesPage = React.lazy(() => import('./components/invoices/InvoicesPage'));
+const InvoiceDetail = React.lazy(() => import('./components/invoices/InvoiceDetail'));
+const ServiceLogsList = React.lazy(() => import('./components/service-logs/ServiceLogsList'));
+const EFilePage = React.lazy(() => import('./components/efile/EFilePage'));
+const AdminPage = React.lazy(() => import('./components/admin/AdminPage'));
+const WorkflowDashboard = React.lazy(() => import('./components/workflows/WorkflowDashboard'));
+const WorkflowDetail = React.lazy(() => import('./components/workflows/WorkflowDetail'));
+const TemplateList = React.lazy(() => import('./components/document-templates/TemplateList'));
+const TemplateDetail = React.lazy(() => import('./components/document-templates/TemplateDetail'));
+const DocumentGenerator = React.lazy(() => import('./components/document-templates/DocumentGenerator'));
+const CalendarPage = React.lazy(() => import('./components/calendar/CalendarPage'));
+const NotificationsPage = React.lazy(() => import('./components/notifications/NotificationsPage'));
+const NotificationScheduler = React.lazy(() => import('./components/notifications/NotificationScheduler'));
+const ContactsPage = React.lazy(() => import('./components/contacts/ContactsPage'));
+const ActivityPage = React.lazy(() => import('./components/activity/ActivityPage'));
+const ProfilePage = React.lazy(() => import('./components/user/ProfilePage'));
+const SettingsPage = React.lazy(() => import('./components/user/SettingsPage'));
 import ErrorBoundary from './components/ui/ErrorBoundary';
 import CardTestPage from './components/ui/CardTestPage';
 import CardShowcase from './components/ui/CardShowcase';
@@ -136,31 +136,164 @@ const AppContent = () => {
             />
           </div>
         } />
-        <Route path="/calendar" element={<CalendarPage />} />
-        <Route path="/documents" element={<DocumentManagement />}>
+        <Route
+          path="/calendar"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading calendar...</div>}>
+              <CalendarPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/documents"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading documents...</div>}>
+              <DocumentManagement />
+            </Suspense>
+          }
+        >
           <Route index element={
             <Suspense fallback={<div className="p-8 text-center">Loading documents...</div>}>
               <DocumentList />
             </Suspense>
           } />
-          <Route path="upload" element={<DocumentUploadForm />} />
-          <Route path="efile" element={<EFilePage />} />
-          <Route path="service-logs" element={<ServiceLogsList />} />
+          <Route
+            path="upload"
+            element={
+              <Suspense fallback={<div className="p-4">Loading upload form...</div>}>
+                <DocumentUploadForm />
+              </Suspense>
+            }
+          />
+          <Route
+            path="efile"
+            element={
+              <Suspense fallback={<div className="p-4">Loading e-file...</div>}>
+                <EFilePage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="service-logs"
+            element={
+              <Suspense fallback={<div className="p-4">Loading service logs...</div>}>
+                <ServiceLogsList />
+              </Suspense>
+            }
+          />
         </Route>
-        <Route path="/documents/:id" element={<DocumentDetail />} />
-        <Route path="/invoices" element={<InvoicesPage />} />
-        <Route path="/invoices/:id" element={<InvoiceDetail />} />
-        <Route path="/workflows" element={<WorkflowDashboard />} />
-        <Route path="/workflows/:id" element={<WorkflowDetail />} />
-        <Route path="/templates" element={<TemplateList />} />
-        <Route path="/templates/:id" element={<TemplateDetail />} />
-        <Route path="/document-generator" element={<DocumentGenerator />} />
-        <Route path="/admin" element={<AdminPage />} />
-        <Route path="/notifications" element={<NotificationsPage />} />
-        <Route path="/activity" element={<ActivityPage />} />
-        <Route path="/contacts/*" element={<ContactsPage />} />
-        <Route path="/profile" element={<ProfilePage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route
+          path="/documents/:id"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading document...</div>}>
+              <DocumentDetail />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/invoices"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading invoices...</div>}>
+              <InvoicesPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/invoices/:id"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading invoice...</div>}>
+              <InvoiceDetail />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/workflows"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading workflows...</div>}>
+              <WorkflowDashboard />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/workflows/:id"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading workflow...</div>}>
+              <WorkflowDetail />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/templates"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading templates...</div>}>
+              <TemplateList />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/templates/:id"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading template...</div>}>
+              <TemplateDetail />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/document-generator"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading generator...</div>}>
+              <DocumentGenerator />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/admin"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading admin...</div>}>
+              <AdminPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/notifications"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading notifications...</div>}>
+              <NotificationsPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/activity"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading activity...</div>}>
+              <ActivityPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/contacts/*"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading contacts...</div>}>
+              <ContactsPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading profile...</div>}>
+              <ProfilePage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <Suspense fallback={<div className="p-8 text-center">Loading settings...</div>}>
+              <SettingsPage />
+            </Suspense>
+          }
+        />
         </Routes>
       </ErrorBoundary>
     </MainLayout>

--- a/src/components/auth/AcceptInvitationPage.tsx
+++ b/src/components/auth/AcceptInvitationPage.tsx
@@ -157,6 +157,7 @@ const AcceptInvitationPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <h2 className="mt-6 text-3xl font-extrabold text-neutral-900">
               Verifying Invitation
@@ -180,6 +181,7 @@ const AcceptInvitationPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <div className="mt-6">
               <AlertCircle className="mx-auto h-12 w-12 text-red-500" />
@@ -213,6 +215,7 @@ const AcceptInvitationPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <div className="mt-6">
               <CheckCircle className="mx-auto h-12 w-12 text-green-500" />
@@ -239,6 +242,7 @@ const AcceptInvitationPage: React.FC = () => {
             className="mx-auto h-16 w-auto"
             src="/wszmainlogo.webp"
             alt="WSZ Legal Logo"
+            loading="lazy"
           />
           <h2 className="mt-6 text-center text-3xl font-extrabold text-neutral-900">
             Complete Your Account Setup

--- a/src/components/auth/ForgotPasswordPage.tsx
+++ b/src/components/auth/ForgotPasswordPage.tsx
@@ -42,6 +42,7 @@ const ForgotPasswordPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <div className="mt-6">
               <CheckCircle className="mx-auto h-12 w-12 text-green-500" />
@@ -86,6 +87,7 @@ const ForgotPasswordPage: React.FC = () => {
             className="mx-auto h-16 w-auto"
             src="/wszmainlogo.webp"
             alt="WSZ Legal Logo"
+            loading="lazy"
           />
           <h2 className="mt-6 text-center text-3xl font-extrabold text-neutral-900">
             Reset Your Password

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -42,6 +42,7 @@ const LoginPage: React.FC = () => {
             className="mx-auto h-16 w-auto"
             src="/wszmainlogo.webp"
             alt="WSZLLP Logo"
+            loading="lazy"
           />
           <Typography 
             variant="h2" 

--- a/src/components/auth/RegisterPage.tsx
+++ b/src/components/auth/RegisterPage.tsx
@@ -62,6 +62,7 @@ const RegisterPage: React.FC = () => {
             className="mx-auto h-16 w-auto"
             src="/wszmainlogo.webp"
             alt="WSZLLP Logo"
+            loading="lazy"
           />
           <h2 className="mt-6 text-center text-3xl font-extrabold text-neutral-900">
             Create your account

--- a/src/components/auth/ResetPasswordPage.tsx
+++ b/src/components/auth/ResetPasswordPage.tsx
@@ -126,6 +126,7 @@ const ResetPasswordPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <h2 className="mt-6 text-3xl font-extrabold text-neutral-900">
               Verifying Reset Link
@@ -149,6 +150,7 @@ const ResetPasswordPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <div className="mt-6">
               <AlertCircle className="mx-auto h-12 w-12 text-red-500" />
@@ -189,6 +191,7 @@ const ResetPasswordPage: React.FC = () => {
               className="mx-auto h-16 w-auto"
               src="/wszmainlogo.webp"
               alt="WSZ Legal Logo"
+              loading="lazy"
             />
             <div className="mt-6">
               <CheckCircle className="mx-auto h-12 w-12 text-green-500" />
@@ -215,6 +218,7 @@ const ResetPasswordPage: React.FC = () => {
             className="mx-auto h-16 w-auto"
             src="/wszmainlogo.webp"
             alt="WSZ Legal Logo"
+            loading="lazy"
           />
           <h2 className="mt-6 text-center text-3xl font-extrabold text-neutral-900">
             Set New Password

--- a/src/components/ui/table-columns/common-columns.tsx
+++ b/src/components/ui/table-columns/common-columns.tsx
@@ -236,10 +236,11 @@ export const commonColumns = {
           {showAvatar && (
             <div className="flex-shrink-0">
               {avatar ? (
-                <img 
-                  className="h-8 w-8 rounded-full object-cover" 
-                  src={avatar} 
+                <img
+                  className="h-8 w-8 rounded-full object-cover"
+                  src={avatar}
                   alt={name}
+                  loading="lazy"
                 />
               ) : (
                 <div className="h-8 w-8 rounded-full bg-neutral-200 flex items-center justify-center">

--- a/src/components/user/ProfilePage.tsx
+++ b/src/components/user/ProfilePage.tsx
@@ -174,10 +174,11 @@ const ProfilePage: React.FC = () => {
             <>
               <div className="flex items-center mb-6">
                 {profile.avatar_url ? (
-                  <img 
-                    src={profile.avatar_url} 
-                    alt={profile.full_name || 'User avatar'} 
+                  <img
+                    src={profile.avatar_url}
+                    alt={profile.full_name || 'User avatar'}
                     className="w-20 h-20 rounded-full object-cover mr-4"
+                    loading="lazy"
                   />
                 ) : (
                   <div className="w-20 h-20 rounded-full bg-primary-100 text-primary-600 flex items-center justify-center mr-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ const { fontFamily } = require("tailwindcss/defaultTheme")
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  mode: 'jit',
   darkMode: ["class"],
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {

--- a/vercel.json
+++ b/vercel.json
@@ -13,5 +13,16 @@
     "env": {
       "NEXT_PUBLIC_EXCLUDE_DEV_TOOLS": "true"
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/(.*)\.(js|css|png|jpg|jpeg|gif|svg|webp|woff2)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -93,12 +93,23 @@ export default defineConfig({
     noExternal: ['papaparse'],
   },
   build: {
+    chunkSizeWarningLimit: 1000,
     rollupOptions: {
       external: [
         /^dev-tools\//,
         'agent.ts',
         'refactor.ts'
-      ]
+      ],
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('react')) return 'vendor-react';
+            if (id.includes('@supabase')) return 'vendor-supabase';
+            if (id.includes('xlsx')) return 'vendor-xlsx';
+            if (id.includes('lucide-react')) return 'vendor-icons';
+          }
+        }
+      }
     }
   },
 });


### PR DESCRIPTION
## Summary
- split large vendor chunks with manualChunks
- lazy load most routes and add Suspense fallbacks
- enable JIT mode in Tailwind config
- tweak preload tags and cache headers
- lazily load static images for better LCP

## Testing
- `npm run build`
- `npm test` *(fails: Database error creating document, unable to find elements)*

------
https://chatgpt.com/codex/tasks/task_e_68557c4f21388325b9cf2570a97997d1